### PR TITLE
Prevent including test directory when installing package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     keywords="api graphql protocol rest",
-    packages=find_packages(exclude=["tests", "tests*"]),
+    packages=find_packages(include=["graphql_server*"]),
     install_requires=install_requires,
     tests_require=install_all_requires + tests_requires,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     keywords="api graphql protocol rest",
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["tests", "tests*"]),
     install_requires=install_requires,
     tests_require=install_all_requires + tests_requires,
     extras_require={


### PR DESCRIPTION
`pip install` and `python setup.py build` also installed the `tests` directory to the environment. I'm not sure about what the best fix is, but this seems to do the trick and [has also been suggested on the internet](https://discuss.python.org/t/excluding-a-package-from-a-wheel-install/861/3).


Example output before the fix, showing the error:

```shell script
$ mkdir foo && pip install . --target foo && ls -l foo  # installing to venv (without --target) had the same problem
... output from pip ...
drwxr-xr-x  3 user user    96 Nov 25 22:25 __pycache__/
drwxr-xr-x 15 user user   480 Nov 25 22:25 graphql/
drwxr-xr-x  8 user user   256 Nov 25 22:25 graphql_core-3.1.2.dist-info/
drwxr-xr-x 12 user user   384 Nov 25 22:25 graphql_server/
drwxr-xr-x  9 user user   288 Nov 25 22:25 graphql_server-3.0.0b2-py3.8.egg-info/
drwxr-xr-x  7 user user   224 Nov 25 22:25 tests/
drwxr-xr-x  8 user user   256 Nov 25 22:25 typing_extensions-3.7.4.3.dist-info/
-rw-r--r--  1 user user 83727 Nov 25 22:25 typing_extensions.py
```

```shell script
$ python setup.py build && ls -l build/lib/
running build
running build_py
creating build
creating build/lib
    1 Prevent including test directory when installing package
creating build/lib/graphql_server
copying graphql_server/version.py -> build/lib/graphql_server
copying graphql_server/error.py -> build/lib/graphql_server
copying graphql_server/__init__.py -> build/lib/graphql_server
copying graphql_server/render_graphiql.py -> build/lib/graphql_server
creating build/lib/graphql_server/flask
copying graphql_server/flask/__init__.py -> build/lib/graphql_server/flask
copying graphql_server/flask/graphqlview.py -> build/lib/graphql_server/flask
creating build/lib/graphql_server/aiohttp
    1 [core]
copying graphql_server/aiohttp/__init__.py -> build/lib/graphql_server/aiohttp
copying graphql_server/aiohttp/graphqlview.py -> build/lib/graphql_server/aiohttp
creating build/lib/graphql_server/quart
copying graphql_server/quart/__init__.py -> build/lib/graphql_server/quart
copying graphql_server/quart/graphqlview.py -> build/lib/graphql_server/quart
creating build/lib/graphql_server/webob
copying graphql_server/webob/__init__.py -> build/lib/graphql_server/webob
copying graphql_server/webob/graphqlview.py -> build/lib/graphql_server/webob
creating build/lib/graphql_server/sanic
copying graphql_server/sanic/__init__.py -> build/lib/graphql_server/sanic
copying graphql_server/sanic/graphqlview.py -> build/lib/graphql_server/sanic
creating build/lib/tests
creating build/lib/tests/flask
copying tests/flask/test_graphiqlview.py -> build/lib/tests/flask
copying tests/flask/test_graphqlview.py -> build/lib/tests/flask
copying tests/flask/__init__.py -> build/lib/tests/flask
copying tests/flask/app.py -> build/lib/tests/flask
copying tests/flask/schema.py -> build/lib/tests/flask
creating build/lib/tests/aiohttp
copying tests/aiohttp/test_graphiqlview.py -> build/lib/tests/aiohttp
copying tests/aiohttp/test_graphqlview.py -> build/lib/tests/aiohttp
copying tests/aiohttp/__init__.py -> build/lib/tests/aiohttp
copying tests/aiohttp/app.py -> build/lib/tests/aiohttp
copying tests/aiohttp/schema.py -> build/lib/tests/aiohttp
creating build/lib/tests/quart
copying tests/quart/test_graphiqlview.py -> build/lib/tests/quart
copying tests/quart/test_graphqlview.py -> build/lib/tests/quart
copying tests/quart/__init__.py -> build/lib/tests/quart
copying tests/quart/app.py -> build/lib/tests/quart
copying tests/quart/schema.py -> build/lib/tests/quart
creating build/lib/tests/webob
copying tests/webob/test_graphiqlview.py -> build/lib/tests/webob
copying tests/webob/test_graphqlview.py -> build/lib/tests/webob
copying tests/webob/__init__.py -> build/lib/tests/webob
copying tests/webob/app.py -> build/lib/tests/webob
copying tests/webob/schema.py -> build/lib/tests/webob
creating build/lib/tests/sanic
copying tests/sanic/test_graphiqlview.py -> build/lib/tests/sanic
copying tests/sanic/test_graphqlview.py -> build/lib/tests/sanic
copying tests/sanic/__init__.py -> build/lib/tests/sanic
copying tests/sanic/app.py -> build/lib/tests/sanic
copying tests/sanic/schema.py -> build/lib/tests/sanic
running egg_info
writing graphql_server.egg-info/PKG-INFO
writing dependency_links to graphql_server.egg-info/dependency_links.txt
writing requirements to graphql_server.egg-info/requires.txt
writing top-level names to graphql_server.egg-info/top_level.txt
reading manifest file 'graphql_server.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
no previously-included directories found matching 'bin'
warning: no previously-included files matching '*.py[co]' found anywhere in distribution
warning: no previously-included files matching '__pycache__' found anywhere in distribution
writing manifest file 'graphql_server.egg-info/SOURCES.txt'
total 0
drwxr-xr-x 11 user user 352 Nov 25 22:25 graphql_server/
drwxr-xr-x  7 user user 224 Nov 25 22:25 tests/
```