### PR TITLE
Relax flask dependency to allow flask 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ dev_requires = [
 ] + tests_requires
 
 install_flask_requires = [
-    "flask>=1,<2",
+    "flask>=1,<3",
 ]
 
 install_sanic_requires = [


### PR DESCRIPTION
Currently, this library requires flask<2, and will not install alongside flask 2.0 or newer. 
Reading the flask release notes, and also testing with this patch, suggests that the changes in 2.0 do not affect this package, so we can relax the dependency and declare support for flask 2