### PR TITLE
Pin depedencies to fix tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ tests_requires = [
     "pytest-cov>=3,<4",
     "aiohttp>=3.8,<4",
     "Jinja2>=2.11,<3",
+    "MarkupSafe>=2.0.1,<2.1.0",
 ]
 
 dev_requires = [
@@ -35,7 +36,7 @@ install_aiohttp_requires = [
     "aiohttp>=3.8,<4",
 ]
 
-install_quart_requires = ["quart>=0.6.15,<0.15"]
+install_quart_requires = ["quart>=0.6.15,<0.15", "wsproto<=1.0.0"]
 
 install_all_requires = (
     install_requires


### PR DESCRIPTION
This PR pins a couple of depedencies in order to avoid import errors due to interface changes in those dependencies (they're mostly, dependencies of dependencies)

* `MarkupSafe<=2.0.1`, above that version the following happens during the tests -> (https://github.com/pallets/jinja/issues/1585)
* `wsproto<=1.0.01`, couldn't find a relevant issue but in 1.0.1 they do [`from h1._headers import Headers as ...`](https://github.com/python-hyper/wsproto/compare/1.0.0...1.1.0#diff-bdde74721eddce34f5e45e6caa2d2eb82f68b660ebd90cea24ba49012c7e3f29R10-R12) and `Headers` was renamed in version [0.11.0](https://h11.readthedocs.io/en/latest/changes.html#v0-11-0-2020-10-05). The project was installing h11 version 0.9.0 I believe.