### PR TITLE
Correctly escape variables when templating GraphiQL response

### DIFF
--- a/graphql_server/render_graphiql.py
+++ b/graphql_server/render_graphiql.py
@@ -230,12 +230,12 @@ def escape_js_value(value: Any) -> Any:
 
 
 def process_var(template: str, name: str, value: Any, jsonify=False) -> str:
-    pattern = r"{{\s*" + name + r"(\s*|[^}]+)*\s*}}"
+    pattern = r"{{\s*" + re.escape(name) + r"(\s*|[^}]+)*\s*}}"
     if jsonify and value not in ["null", "undefined"]:
         value = json.dumps(value)
         value = escape_js_value(value)
 
-    return re.sub(pattern, value, template)
+    return re.sub(pattern, re.escape(value), template)
 
 
 def simple_renderer(template: str, **values: Dict[str, Any]) -> str:

--- a/tests/flask/test_graphiqlview.py
+++ b/tests/flask/test_graphiqlview.py
@@ -44,6 +44,18 @@ def test_graphiql_renders_pretty(app, client):
 
     assert pretty_response in response.data.decode("utf-8")
 
+def test_graphiql_renders_umlauts_pretty(app, client):
+    with app.test_request_context():
+        response = client.get(
+            url_for(
+                "graphql",
+                query="query helloWho($who: String){ test(who: $who) }",
+                variables='{"who": "Björn"}',
+            ), headers={"Accept": "text/html"}
+        )
+    assert response.status_code == 200
+    assert "Hello\\ Bj\\\\u00f6rn" in response.data.decode("utf-8")
+
 
 def test_graphiql_default_title(app, client):
     with app.test_request_context():


### PR DESCRIPTION
This commit makes sure that values are escaped correctly when doing `re.sub()` while rendering a GraphiQL response. This is necessary when non-ASCII characters end up in the GraphQL variables, for example an umlaut. `json.dumps()`encodes such characters using a unicode escape sequence starting with `\u`, which isn't a valid regex. Hence, we would get this error:

```
re.error: bad escape \u at position 11
```

<details>
<summary>Traceback</summary>

```
../.venv/lib/python3.9/site-packages/werkzeug/test.py:1006: in get
    return self.open(*args, **kw)
../.venv/lib/python3.9/site-packages/flask/testing.py:222: in open
    return Client.open(
../.venv/lib/python3.9/site-packages/werkzeug/test.py:970: in open
    response = self.run_wsgi_app(environ.copy(), buffered=buffered)
../.venv/lib/python3.9/site-packages/werkzeug/test.py:861: in run_wsgi_app
    rv = run_wsgi_app(self.application, environ, buffered=buffered)
../.venv/lib/python3.9/site-packages/werkzeug/test.py:1096: in run_wsgi_app
    app_rv = app(environ, start_response)
../.venv/lib/python3.9/site-packages/flask/app.py:2464: in __call__
    return self.wsgi_app(environ, start_response)
../.venv/lib/python3.9/site-packages/flask/app.py:2450: in wsgi_app
    response = self.handle_exception(e)
../.venv/lib/python3.9/site-packages/flask/app.py:1867: in handle_exception
    reraise(exc_type, exc_value, tb)
../.venv/lib/python3.9/site-packages/flask/_compat.py:39: in reraise
    raise value
../.venv/lib/python3.9/site-packages/flask/app.py:2447: in wsgi_app
    response = self.full_dispatch_request()
../.venv/lib/python3.9/site-packages/flask/app.py:1952: in full_dispatch_request
    rv = self.handle_user_exception(e)
../.venv/lib/python3.9/site-packages/flask/app.py:1821: in handle_user_exception
    reraise(exc_type, exc_value, tb)
../.venv/lib/python3.9/site-packages/flask/_compat.py:39: in reraise
    raise value
../.venv/lib/python3.9/site-packages/flask/app.py:1950: in full_dispatch_request
    rv = self.dispatch_request()
../.venv/lib/python3.9/site-packages/flask/app.py:1936: in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
../.venv/lib/python3.9/site-packages/flask/views.py:89: in view
    return self.dispatch_request(*args, **kwargs)
../graphql_server/flask/graphqlview.py:136: in dispatch_request
    source = render_graphiql_sync(
../graphql_server/render_graphiql.py:329: in render_graphiql_sync
    source = simple_renderer(graphiql_template, **template_vars)
../graphql_server/render_graphiql.py:262: in simple_renderer
    template = process_var(template, r, values.get(r, ""), True)
../graphql_server/render_graphiql.py:238: in process_var
    return re.sub(pattern, value, template)
/nix/store/x26srysgpc16zvxz5fdk0kdqd92i4h5i-python3-3.9.13/lib/python3.9/re.py:210: in sub
    return _compile(pattern, flags).sub(repl, string, count)
/nix/store/x26srysgpc16zvxz5fdk0kdqd92i4h5i-python3-3.9.13/lib/python3.9/re.py:327: in _subx
    template = _compile_repl(template, pattern)
/nix/store/x26srysgpc16zvxz5fdk0kdqd92i4h5i-python3-3.9.13/lib/python3.9/re.py:318: in _compile_repl
    return sre_parse.parse_template(repl, pattern)
```

</details>

We get around this by `re.escape()`-ing everything before doing anything
regexy with it.