### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Build wheel and source tarball
       run: |
         pip install wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,22 +8,22 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
         exclude:
-          - os: windows-latest
-            python-version: "3.6"
           - os: windows-latest
             python-version: "3.7"
           - os: windows-latest
             python-version: "3.8"
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.11"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -39,11 +39,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip

--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -9,17 +9,7 @@ for building GraphQL servers or integrations into existing web frameworks using
 import json
 from collections import namedtuple
 from collections.abc import MutableMapping
-from typing import (
-    Any,
-    Callable,
-    Collection,
-    Dict,
-    List,
-    Optional,
-    Type,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Collection, Dict, List, Optional, Type, Union, cast
 
 from graphql.error import GraphQLError
 from graphql.execution import ExecutionResult, execute

--- a/graphql_server/quart/graphqlview.py
+++ b/graphql_server/quart/graphqlview.py
@@ -1,5 +1,4 @@
 import copy
-import sys
 from collections.abc import MutableMapping
 from functools import partial
 from typing import List
@@ -191,20 +190,8 @@ class GraphQLView(View):
     def request_wants_html():
         best = request.accept_mimetypes.best_match(["application/json", "text/html"])
 
-        # Needed as this was introduced at Quart 0.8.0: https://gitlab.com/pgjones/quart/-/issues/189
-        def _quality(accept, key: str) -> float:
-            for option in accept.options:
-                if accept._values_match(key, option.value):
-                    return option.quality
-            return 0.0
-
-        if sys.version_info >= (3, 7):
-            return (
-                best == "text/html"
-                and request.accept_mimetypes[best]
-                > request.accept_mimetypes["application/json"]
-            )
-        else:
-            return best == "text/html" and _quality(
-                request.accept_mimetypes, best
-            ) > _quality(request.accept_mimetypes, "application/json")
+        return (
+            best == "text/html"
+            and request.accept_mimetypes[best]
+            > request.accept_mimetypes["application/json"]
+        )

--- a/graphql_server/quart/graphqlview.py
+++ b/graphql_server/quart/graphqlview.py
@@ -165,11 +165,11 @@ class GraphQLView(View):
         # information provided by content_type
         content_type = request.mimetype
         if content_type == "application/graphql":
-            refined_data = await request.get_data(raw=False)
+            refined_data = await request.get_data(as_text=True)
             return {"query": refined_data}
 
         elif content_type == "application/json":
-            refined_data = await request.get_data(raw=False)
+            refined_data = await request.get_data(as_text=True)
             return load_json_body(refined_data)
 
         elif content_type == "application/x-www-form-urlencoded":

--- a/graphql_server/render_graphiql.py
+++ b/graphql_server/render_graphiql.py
@@ -1,4 +1,4 @@
-"""Based on (express-graphql)[https://github.com/graphql/express-graphql/blob/master/src/renderGraphiQL.js] and
+"""Based on (express-graphql)[https://github.com/graphql/express-graphql/blob/main/src/renderGraphiQL.ts] and
 (subscriptions-transport-ws)[https://github.com/apollographql/subscriptions-transport-ws]"""
 import json
 import re
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional, Tuple
 from jinja2 import Environment
 from typing_extensions import TypedDict
 
-GRAPHIQL_VERSION = "1.0.3"
+GRAPHIQL_VERSION = "1.4.7"
 
 GRAPHIQL_TEMPLATE = """<!--
 The request to this GraphQL server provided the header "Accept: text/html"
@@ -34,12 +34,12 @@ add "&raw" to the end of the URL within a browser.
     }
   </style>
   <link href="//cdn.jsdelivr.net/npm/graphiql@{{graphiql_version}}/graphiql.css" rel="stylesheet" />
-  <script src="//cdn.jsdelivr.net/npm/promise-polyfill@8.1.3/dist/polyfill.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/unfetch@4.1.0/dist/unfetch.umd.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/react@16.13.1/umd/react.production.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/react-dom@16.13.1/umd/react-dom.production.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/promise-polyfill@8.2.0/dist/polyfill.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/unfetch@4.2.0/dist/unfetch.umd.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/react@16.14.0/umd/react.production.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/react-dom@16.14.0/umd/react-dom.production.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/graphiql@{{graphiql_version}}/graphiql.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/subscriptions-transport-ws@0.9.16/browser/client.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/subscriptions-transport-ws@0.9.18/browser/client.js"></script>
   <script src="//cdn.jsdelivr.net/npm/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
 </head>
 <body>
@@ -308,9 +308,8 @@ async def render_graphiql_async(
     jinja_env: Optional[Environment] = config.get("jinja_env")
 
     if jinja_env:
-        # This method returns a Template. See https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Template
         template = jinja_env.from_string(graphiql_template)
-        if jinja_env.is_async:  # type: ignore
+        if jinja_env.is_async:
             source = await template.render_async(**template_vars)
         else:
             source = template.render(**template_vars)

--- a/graphql_server/sanic/graphqlview.py
+++ b/graphql_server/sanic/graphqlview.py
@@ -85,7 +85,7 @@ class GraphQLView(HTTPMethodView):
             return specified_rules
         return self.validation_rules
 
-    async def dispatch_request(self, request, *args, **kwargs):
+    async def __handle_request(self, request, *args, **kwargs):
         try:
             request_method = request.method.lower()
             data = self.parse_body(request)
@@ -172,6 +172,8 @@ class GraphQLView(HTTPMethodView):
                 headers=e.headers,
                 content_type="application/json",
             )
+
+    get = post = put = head = options = patch = delete = __handle_request
 
     # noinspection PyBroadException
     def parse_body(self, request):

--- a/graphql_server/webob/graphqlview.py
+++ b/graphql_server/webob/graphqlview.py
@@ -27,7 +27,6 @@ from graphql_server.render_graphiql import (
 
 class GraphQLView:
     schema = None
-    request = None
     root_value = None
     context = None
     pretty = False
@@ -187,8 +186,9 @@ class GraphQLView:
         if not self.graphiql or "raw" in request.params:
             return False
 
-        return self.request_wants_html()
+        return self.request_wants_html(request)
 
-    def request_wants_html(self):
-        best = self.request.accept.best_match(["application/json", "text/html"])
+    @staticmethod
+    def request_wants_html(request):
+        best = request.accept.best_match(["application/json", "text/html"])
         return best == "text/html"

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ ignore = E203, E501, W503
 
 [isort]
 known_first_party=graphql_server
+profile=black
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ tests_requires = [
     "pytest>=7.2,<8",
     "pytest-asyncio>=0.20,<1",
     "pytest-cov>=4,<5",
-    "sanic-testing>=22.3,<22.7",
+    "sanic-testing>=22.3,<23",
 ]
 
 dev_requires = [
@@ -27,7 +27,7 @@ install_flask_requires = [
 ]
 
 install_sanic_requires = [
-    "sanic>=21.12,<22.7",
+    "sanic>=21.12,<23",
 ]
 
 install_webob_requires = [

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,23 @@
 from re import search
 from setuptools import setup, find_packages
 
-install_requires = ["graphql-core>=3.2,<3.3", "typing-extensions>=4,<5"]
+install_requires = [
+    "graphql-core>=3.2,<3.3",
+    "Jinja2>=3.1,<4",
+    "typing-extensions>=4,<5",
+]
 
 tests_requires = [
-    "pytest>=6.2,<6.3",
-    "pytest-asyncio>=0.16,<1",
-    "pytest-cov>=3,<4",
-    "aiohttp>=3.8,<4",
-    "Jinja2>=2.11,<3",
+    "pytest>=7.2,<8",
+    "pytest-asyncio>=0.20,<1",
+    "pytest-cov>=4,<5",
 ]
 
 dev_requires = [
-    "flake8>=4,<5",
+    "flake8>=5,<6",
     "isort>=5,<6",
-    "black>=19.10b0",
-    "mypy>=0.931,<1",
+    "black>=22.12,<22.13",
+    "mypy>=0.991,<1",
     "check-manifest>=0.47,<1",
 ] + tests_requires
 
@@ -35,7 +37,7 @@ install_aiohttp_requires = [
     "aiohttp>=3.8,<4",
 ]
 
-install_quart_requires = ["quart>=0.6.15,<0.15"]
+install_quart_requires = ["quart>=0.15,<1"]
 
 install_all_requires = (
     install_requires

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ dev_requires = [
 ] + tests_requires
 
 install_flask_requires = [
-    "flask>=1,<2",
+    "flask>=1,<3",
 ]
 
 install_sanic_requires = [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 
 install_requires = [
     "graphql-core>=3.2,<3.3",
-    "Jinja2>=3.1,<4",
     "typing-extensions>=4,<5",
 ]
 
@@ -11,6 +10,7 @@ tests_requires = [
     "pytest>=7.2,<8",
     "pytest-asyncio>=0.20,<1",
     "pytest-cov>=4,<5",
+    "Jinja2>=3.1,<4",
     "sanic-testing>=22.3,<23",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ tests_requires = [
     "pytest>=7.2,<8",
     "pytest-asyncio>=0.20,<1",
     "pytest-cov>=4,<5",
+    "sanic-testing>=22.3,<22.7",
 ]
 
 dev_requires = [
@@ -26,7 +27,7 @@ install_flask_requires = [
 ]
 
 install_sanic_requires = [
-    "sanic>=20.3,<21",
+    "sanic>=21.12,<22.7",
 ]
 
 install_webob_requires = [

--- a/tests/aiohttp/test_graphiqlview.py
+++ b/tests/aiohttp/test_graphiqlview.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 from aiohttp.test_utils import TestClient, TestServer
 from jinja2 import Environment
 
@@ -12,7 +13,7 @@ def app():
     return app
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client(app):
     client = TestClient(TestServer(app))
     await client.start_server()

--- a/tests/aiohttp/test_graphqlview.py
+++ b/tests/aiohttp/test_graphqlview.py
@@ -2,6 +2,7 @@ import json
 from urllib.parse import urlencode
 
 import pytest
+import pytest_asyncio
 from aiohttp import FormData
 from aiohttp.test_utils import TestClient, TestServer
 
@@ -15,7 +16,7 @@ def app():
     return app
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client(app):
     client = TestClient(TestServer(app))
     await client.start_server()

--- a/tests/quart/conftest.py
+++ b/tests/quart/conftest.py
@@ -1,0 +1,3 @@
+from quart.typing import TestClientProtocol
+
+TestClientProtocol.__test__ = False  # type: ignore

--- a/tests/sanic/app.py
+++ b/tests/sanic/app.py
@@ -1,7 +1,6 @@
 from urllib.parse import urlencode
 
 from sanic import Sanic
-from sanic.testing import SanicTestClient
 
 from graphql_server.sanic import GraphQLView
 
@@ -11,13 +10,11 @@ Sanic.test_mode = True
 
 
 def create_app(path="/graphql", **kwargs):
-    app = Sanic(__name__)
-    app.debug = True
+    app = Sanic("TestApp")
 
     schema = kwargs.pop("schema", None) or Schema
     app.add_route(GraphQLView.as_view(schema=schema, **kwargs), path)
 
-    app.client = SanicTestClient(app)
     return app
 
 

--- a/tests/sanic/app.py
+++ b/tests/sanic/app.py
@@ -1,3 +1,4 @@
+import uuid
 from urllib.parse import urlencode
 
 from sanic import Sanic
@@ -6,11 +7,10 @@ from graphql_server.sanic import GraphQLView
 
 from .schema import Schema
 
-Sanic.test_mode = True
-
 
 def create_app(path="/graphql", **kwargs):
-    app = Sanic("TestApp")
+    random_valid_app_name = f"App{uuid.uuid4().hex}"
+    app = Sanic(random_valid_app_name)
 
     schema = kwargs.pop("schema", None) or Schema
     app.add_route(GraphQLView.as_view(schema=schema, **kwargs), path)

--- a/tests/sanic/test_graphiqlview.py
+++ b/tests/sanic/test_graphiqlview.py
@@ -18,7 +18,7 @@ def pretty_response():
 
 @pytest.mark.parametrize("app", [create_app(graphiql=True)])
 def test_graphiql_is_enabled(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(query="{test}"), headers={"Accept": "text/html"}
     )
     assert response.status == 200
@@ -26,7 +26,7 @@ def test_graphiql_is_enabled(app):
 
 @pytest.mark.parametrize("app", [create_app(graphiql=True)])
 def test_graphiql_simple_renderer(app, pretty_response):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(query="{test}"), headers={"Accept": "text/html"}
     )
     assert response.status == 200
@@ -35,7 +35,7 @@ def test_graphiql_simple_renderer(app, pretty_response):
 
 @pytest.mark.parametrize("app", [create_app(graphiql=True, jinja_env=Environment())])
 def test_graphiql_jinja_renderer(app, pretty_response):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(query="{test}"), headers={"Accept": "text/html"}
     )
     assert response.status == 200
@@ -46,7 +46,7 @@ def test_graphiql_jinja_renderer(app, pretty_response):
     "app", [create_app(graphiql=True, jinja_env=Environment(enable_async=True))]
 )
 def test_graphiql_jinja_async_renderer(app, pretty_response):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(query="{test}"), headers={"Accept": "text/html"}
     )
     assert response.status == 200
@@ -55,7 +55,7 @@ def test_graphiql_jinja_async_renderer(app, pretty_response):
 
 @pytest.mark.parametrize("app", [create_app(graphiql=True)])
 def test_graphiql_html_is_not_accepted(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(), headers={"Accept": "application/json"}
     )
     assert response.status == 400
@@ -66,7 +66,7 @@ def test_graphiql_html_is_not_accepted(app):
 )
 def test_graphiql_enabled_async_schema(app):
     query = "{a,b,c}"
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(query=query), headers={"Accept": "text/html"}
     )
 
@@ -93,7 +93,7 @@ def test_graphiql_enabled_async_schema(app):
 )
 def test_graphiql_enabled_sync_schema(app):
     query = "{a,b}"
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(query=query), headers={"Accept": "text/html"}
     )
 

--- a/tests/sanic/test_graphqlview.py
+++ b/tests/sanic/test_graphqlview.py
@@ -166,7 +166,7 @@ def test_allows_mutation_to_exist_within_a_get(app):
 def test_allows_post_with_json_encoding(app):
     _, response = app.test_client.post(
         uri=url_string(),
-        data=json_dump_kwarg(query="{test}"),
+        content=json_dump_kwarg(query="{test}"),
         headers={"content-type": "application/json"},
     )
 
@@ -178,7 +178,7 @@ def test_allows_post_with_json_encoding(app):
 def test_allows_sending_a_mutation_via_post(app):
     _, response = app.test_client.post(
         uri=url_string(),
-        data=json_dump_kwarg(query="mutation TestMutation { writeTest { test } }"),
+        content=json_dump_kwarg(query="mutation TestMutation { writeTest { test } }"),
         headers={"content-type": "application/json"},
     )
 
@@ -194,7 +194,7 @@ def test_allows_post_with_url_encoding(app):
     payload = "query={test}"
     _, response = app.test_client.post(
         uri=url_string(),
-        data=payload,
+        content=payload,
         headers={"content-type": "application/x-www-form-urlencoded"},
     )
 
@@ -206,7 +206,7 @@ def test_allows_post_with_url_encoding(app):
 def test_supports_post_json_query_with_string_variables(app):
     _, response = app.test_client.post(
         uri=url_string(),
-        data=json_dump_kwarg(
+        content=json_dump_kwarg(
             query="query helloWho($who: String){ test(who: $who) }",
             variables=json.dumps({"who": "Dolly"}),
         ),
@@ -221,7 +221,7 @@ def test_supports_post_json_query_with_string_variables(app):
 def test_supports_post_json_query_with_json_variables(app):
     _, response = app.test_client.post(
         uri=url_string(),
-        data=json_dump_kwarg(
+        content=json_dump_kwarg(
             query="query helloWho($who: String){ test(who: $who) }",
             variables={"who": "Dolly"},
         ),
@@ -236,7 +236,7 @@ def test_supports_post_json_query_with_json_variables(app):
 def test_supports_post_url_encoded_query_with_string_variables(app):
     _, response = app.test_client.post(
         uri=url_string(),
-        data=urlencode(
+        content=urlencode(
             dict(
                 query="query helloWho($who: String){ test(who: $who) }",
                 variables=json.dumps({"who": "Dolly"}),
@@ -253,7 +253,7 @@ def test_supports_post_url_encoded_query_with_string_variables(app):
 def test_supports_post_json_query_with_get_variable_values(app):
     _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
-        data=json_dump_kwarg(
+        content=json_dump_kwarg(
             query="query helloWho($who: String){ test(who: $who) }",
         ),
         headers={"content-type": "application/json"},
@@ -267,7 +267,7 @@ def test_supports_post_json_query_with_get_variable_values(app):
 def test_post_url_encoded_query_with_get_variable_values(app):
     _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
-        data=urlencode(
+        content=urlencode(
             dict(
                 query="query helloWho($who: String){ test(who: $who) }",
             )
@@ -283,7 +283,7 @@ def test_post_url_encoded_query_with_get_variable_values(app):
 def test_supports_post_raw_text_query_with_get_variable_values(app):
     _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
-        data="query helloWho($who: String){ test(who: $who) }",
+        content="query helloWho($who: String){ test(who: $who) }",
         headers={"content-type": "application/graphql"},
     )
 
@@ -295,7 +295,7 @@ def test_supports_post_raw_text_query_with_get_variable_values(app):
 def test_allows_post_with_operation_name(app):
     _, response = app.test_client.post(
         uri=url_string(),
-        data=json_dump_kwarg(
+        content=json_dump_kwarg(
             query="""
         query helloYou { test(who: "You"), ...shared }
         query helloWorld { test(who: "World"), ...shared }
@@ -319,7 +319,7 @@ def test_allows_post_with_operation_name(app):
 def test_allows_post_with_get_operation_name(app):
     _, response = app.test_client.post(
         uri=url_string(operationName="helloWorld"),
-        data="""
+        content="""
     query helloYou { test(who: "You"), ...shared }
     query helloWorld { test(who: "World"), ...shared }
     query helloDolly { test(who: "Dolly"), ...shared }
@@ -404,7 +404,7 @@ def test_handles_errors_caused_by_a_lack_of_query(app):
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_batch_correctly_if_is_disabled(app):
     _, response = app.test_client.post(
-        uri=url_string(), data="[]", headers={"content-type": "application/json"}
+        uri=url_string(), content="[]", headers={"content-type": "application/json"}
     )
 
     assert response.status == 400
@@ -420,7 +420,9 @@ def test_handles_batch_correctly_if_is_disabled(app):
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_incomplete_json_bodies(app):
     _, response = app.test_client.post(
-        uri=url_string(), data='{"query":', headers={"content-type": "application/json"}
+        uri=url_string(),
+        content='{"query":',
+        headers={"content-type": "application/json"},
     )
 
     assert response.status == 400
@@ -433,7 +435,7 @@ def test_handles_incomplete_json_bodies(app):
 def test_handles_plain_post_text(app):
     _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
-        data="query helloWho($who: String){ test(who: $who) }",
+        content="query helloWho($who: String){ test(who: $who) }",
         headers={"content-type": "text/plain"},
     )
     assert response.status == 400
@@ -530,7 +532,7 @@ def test_post_multipart_data(app):
 
     _, response = app.test_client.post(
         uri=url_string(),
-        data=data,
+        content=data,
         headers={"content-type": "multipart/form-data; boundary=----sanicgraphql"},
     )
 
@@ -542,7 +544,7 @@ def test_post_multipart_data(app):
 def test_batch_allows_post_with_json_encoding(app):
     _, response = app.test_client.post(
         uri=url_string(),
-        data=json_dump_kwarg_list(id=1, query="{test}"),
+        content=json_dump_kwarg_list(id=1, query="{test}"),
         headers={"content-type": "application/json"},
     )
 
@@ -554,7 +556,7 @@ def test_batch_allows_post_with_json_encoding(app):
 def test_batch_supports_post_json_query_with_json_variables(app):
     _, response = app.test_client.post(
         uri=url_string(),
-        data=json_dump_kwarg_list(
+        content=json_dump_kwarg_list(
             id=1,
             query="query helloWho($who: String){ test(who: $who) }",
             variables={"who": "Dolly"},
@@ -570,7 +572,7 @@ def test_batch_supports_post_json_query_with_json_variables(app):
 def test_batch_allows_post_with_operation_name(app):
     _, response = app.test_client.post(
         uri=url_string(),
-        data=json_dump_kwarg_list(
+        content=json_dump_kwarg_list(
             id=1,
             query="""
             query helloYou { test(who: "You"), ...shared }

--- a/tests/sanic/test_graphqlview.py
+++ b/tests/sanic/test_graphqlview.py
@@ -21,7 +21,7 @@ def json_dump_kwarg_list(**kwargs):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_allows_get_with_query_param(app):
-    _, response = app.client.get(uri=url_string(query="{test}"))
+    _, response = app.test_client.get(uri=url_string(query="{test}"))
 
     assert response.status == 200
     assert response_json(response) == {"data": {"test": "Hello World"}}
@@ -29,7 +29,7 @@ def test_allows_get_with_query_param(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_allows_get_with_variable_values(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(
             query="query helloWho($who: String){ test(who: $who) }",
             variables=json.dumps({"who": "Dolly"}),
@@ -42,7 +42,7 @@ def test_allows_get_with_variable_values(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_allows_get_with_operation_name(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(
             query="""
         query helloYou { test(who: "You"), ...shared }
@@ -64,7 +64,7 @@ def test_allows_get_with_operation_name(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_reports_validation_errors(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(query="{ test, unknownOne, unknownTwo }")
     )
 
@@ -85,7 +85,7 @@ def test_reports_validation_errors(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_errors_when_missing_operation_name(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(
             query="""
         query TestQuery { test }
@@ -107,7 +107,7 @@ def test_errors_when_missing_operation_name(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_errors_when_sending_a_mutation_via_get(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(
             query="""
         mutation TestMutation { writeTest { test } }
@@ -126,7 +126,7 @@ def test_errors_when_sending_a_mutation_via_get(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_errors_when_selecting_a_mutation_within_a_get(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(
             query="""
         query TestQuery { test }
@@ -148,7 +148,7 @@ def test_errors_when_selecting_a_mutation_within_a_get(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_allows_mutation_to_exist_within_a_get(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(
             query="""
         query TestQuery { test }
@@ -164,7 +164,7 @@ def test_allows_mutation_to_exist_within_a_get(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_allows_post_with_json_encoding(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=json_dump_kwarg(query="{test}"),
         headers={"content-type": "application/json"},
@@ -176,7 +176,7 @@ def test_allows_post_with_json_encoding(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_allows_sending_a_mutation_via_post(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=json_dump_kwarg(query="mutation TestMutation { writeTest { test } }"),
         headers={"content-type": "application/json"},
@@ -192,7 +192,7 @@ def test_allows_post_with_url_encoding(app):
     # can be found at their repo.
     # https://github.com/huge-success/sanic/blob/master/tests/test_requests.py#L927
     payload = "query={test}"
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=payload,
         headers={"content-type": "application/x-www-form-urlencoded"},
@@ -204,7 +204,7 @@ def test_allows_post_with_url_encoding(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_json_query_with_string_variables(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=json_dump_kwarg(
             query="query helloWho($who: String){ test(who: $who) }",
@@ -219,7 +219,7 @@ def test_supports_post_json_query_with_string_variables(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_json_query_with_json_variables(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=json_dump_kwarg(
             query="query helloWho($who: String){ test(who: $who) }",
@@ -234,7 +234,7 @@ def test_supports_post_json_query_with_json_variables(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_url_encoded_query_with_string_variables(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=urlencode(
             dict(
@@ -251,7 +251,7 @@ def test_supports_post_url_encoded_query_with_string_variables(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_json_query_with_get_variable_values(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
         data=json_dump_kwarg(
             query="query helloWho($who: String){ test(who: $who) }",
@@ -265,7 +265,7 @@ def test_supports_post_json_query_with_get_variable_values(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_post_url_encoded_query_with_get_variable_values(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
         data=urlencode(
             dict(
@@ -281,7 +281,7 @@ def test_post_url_encoded_query_with_get_variable_values(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_raw_text_query_with_get_variable_values(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
         data="query helloWho($who: String){ test(who: $who) }",
         headers={"content-type": "application/graphql"},
@@ -293,7 +293,7 @@ def test_supports_post_raw_text_query_with_get_variable_values(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_allows_post_with_operation_name(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=json_dump_kwarg(
             query="""
@@ -317,7 +317,7 @@ def test_allows_post_with_operation_name(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_allows_post_with_get_operation_name(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(operationName="helloWorld"),
         data="""
     query helloYou { test(who: "You"), ...shared }
@@ -338,7 +338,7 @@ def test_allows_post_with_get_operation_name(app):
 
 @pytest.mark.parametrize("app", [create_app(pretty=True)])
 def test_supports_pretty_printing(app):
-    _, response = app.client.get(uri=url_string(query="{test}"))
+    _, response = app.test_client.get(uri=url_string(query="{test}"))
 
     assert response.body.decode() == (
         "{\n" '  "data": {\n' '    "test": "Hello World"\n' "  }\n" "}"
@@ -347,14 +347,14 @@ def test_supports_pretty_printing(app):
 
 @pytest.mark.parametrize("app", [create_app(pretty=False)])
 def test_not_pretty_by_default(app):
-    _, response = app.client.get(url_string(query="{test}"))
+    _, response = app.test_client.get(url_string(query="{test}"))
 
     assert response.body.decode() == '{"data":{"test":"Hello World"}}'
 
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_supports_pretty_printing_by_request(app):
-    _, response = app.client.get(uri=url_string(query="{test}", pretty="1"))
+    _, response = app.test_client.get(uri=url_string(query="{test}", pretty="1"))
 
     assert response.body.decode() == (
         "{\n" '  "data": {\n' '    "test": "Hello World"\n' "  }\n" "}"
@@ -363,7 +363,7 @@ def test_supports_pretty_printing_by_request(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_field_errors_caught_by_graphql(app):
-    _, response = app.client.get(uri=url_string(query="{thrower}"))
+    _, response = app.test_client.get(uri=url_string(query="{thrower}"))
     assert response.status == 200
     assert response_json(response) == {
         "data": None,
@@ -379,7 +379,7 @@ def test_handles_field_errors_caught_by_graphql(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_syntax_errors_caught_by_graphql(app):
-    _, response = app.client.get(uri=url_string(query="syntaxerror"))
+    _, response = app.test_client.get(uri=url_string(query="syntaxerror"))
     assert response.status == 400
     assert response_json(response) == {
         "errors": [
@@ -393,7 +393,7 @@ def test_handles_syntax_errors_caught_by_graphql(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_errors_caused_by_a_lack_of_query(app):
-    _, response = app.client.get(uri=url_string())
+    _, response = app.test_client.get(uri=url_string())
 
     assert response.status == 400
     assert response_json(response) == {
@@ -403,7 +403,7 @@ def test_handles_errors_caused_by_a_lack_of_query(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_batch_correctly_if_is_disabled(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(), data="[]", headers={"content-type": "application/json"}
     )
 
@@ -419,7 +419,7 @@ def test_handles_batch_correctly_if_is_disabled(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_incomplete_json_bodies(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(), data='{"query":', headers={"content-type": "application/json"}
     )
 
@@ -431,7 +431,7 @@ def test_handles_incomplete_json_bodies(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_plain_post_text(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
         data="query helloWho($who: String){ test(who: $who) }",
         headers={"content-type": "text/plain"},
@@ -444,7 +444,7 @@ def test_handles_plain_post_text(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_poorly_formed_variables(app):
-    _, response = app.client.get(
+    _, response = app.test_client.get(
         uri=url_string(
             query="query helloWho($who: String){ test(who: $who) }", variables="who:You"
         )
@@ -457,9 +457,12 @@ def test_handles_poorly_formed_variables(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_handles_unsupported_http_methods(app):
-    _, response = app.client.put(uri=url_string(query="{test}"))
+    _, response = app.test_client.put(uri=url_string(query="{test}"))
     assert response.status == 405
-    assert response.headers["Allow"] in ["GET, POST", "HEAD, GET, POST, OPTIONS"]
+    allowed_methods = set(
+        method.strip() for method in response.headers["Allow"].split(",")
+    )
+    assert allowed_methods in [{"GET", "POST"}, {"HEAD", "GET", "POST", "OPTIONS"}]
     assert response_json(response) == {
         "errors": [
             {
@@ -471,7 +474,7 @@ def test_handles_unsupported_http_methods(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_passes_request_into_request_context(app):
-    _, response = app.client.get(uri=url_string(query="{request}", q="testing"))
+    _, response = app.test_client.get(uri=url_string(query="{request}", q="testing"))
 
     assert response.status == 200
     assert response_json(response) == {"data": {"request": "testing"}}
@@ -479,7 +482,9 @@ def test_passes_request_into_request_context(app):
 
 @pytest.mark.parametrize("app", [create_app(context={"session": "CUSTOM CONTEXT"})])
 def test_passes_custom_context_into_context(app):
-    _, response = app.client.get(uri=url_string(query="{context { session request }}"))
+    _, response = app.test_client.get(
+        uri=url_string(query="{context { session request }}")
+    )
 
     assert response.status_code == 200
     res = response_json(response)
@@ -492,7 +497,9 @@ def test_passes_custom_context_into_context(app):
 
 @pytest.mark.parametrize("app", [create_app(context="CUSTOM CONTEXT")])
 def test_context_remapped_if_not_mapping(app):
-    _, response = app.client.get(uri=url_string(query="{context { session request }}"))
+    _, response = app.test_client.get(
+        uri=url_string(query="{context { session request }}")
+    )
 
     assert response.status_code == 200
     res = response_json(response)
@@ -521,7 +528,7 @@ def test_post_multipart_data(app):
         + "------sanicgraphql--\r\n"
     )
 
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=data,
         headers={"content-type": "multipart/form-data; boundary=----sanicgraphql"},
@@ -533,7 +540,7 @@ def test_post_multipart_data(app):
 
 @pytest.mark.parametrize("app", [create_app(batch=True)])
 def test_batch_allows_post_with_json_encoding(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=json_dump_kwarg_list(id=1, query="{test}"),
         headers={"content-type": "application/json"},
@@ -545,7 +552,7 @@ def test_batch_allows_post_with_json_encoding(app):
 
 @pytest.mark.parametrize("app", [create_app(batch=True)])
 def test_batch_supports_post_json_query_with_json_variables(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=json_dump_kwarg_list(
             id=1,
@@ -561,7 +568,7 @@ def test_batch_supports_post_json_query_with_json_variables(app):
 
 @pytest.mark.parametrize("app", [create_app(batch=True)])
 def test_batch_allows_post_with_operation_name(app):
-    _, response = app.client.post(
+    _, response = app.test_client.post(
         uri=url_string(),
         data=json_dump_kwarg_list(
             id=1,
@@ -587,7 +594,7 @@ def test_batch_allows_post_with_operation_name(app):
 @pytest.mark.parametrize("app", [create_app(schema=AsyncSchema, enable_async=True)])
 def test_async_schema(app):
     query = "{a,b,c}"
-    _, response = app.client.get(uri=url_string(query=query))
+    _, response = app.test_client.get(uri=url_string(query=query))
 
     assert response.status == 200
     assert response_json(response) == {"data": {"a": "hey", "b": "hey2", "c": "hey3"}}
@@ -595,7 +602,7 @@ def test_async_schema(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_preflight_request(app):
-    _, response = app.client.options(
+    _, response = app.test_client.options(
         uri=url_string(), headers={"Access-Control-Request-Method": "POST"}
     )
 
@@ -604,7 +611,7 @@ def test_preflight_request(app):
 
 @pytest.mark.parametrize("app", [create_app()])
 def test_preflight_incorrect_request(app):
-    _, response = app.client.options(
+    _, response = app.test_client.options(
         uri=url_string(), headers={"Access-Control-Request-Method": "OPTIONS"}
     )
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -45,8 +45,6 @@ schema = GraphQLSchema(QueryRootType)
 def test_get_responses_using_asyncio_executor():
     query = "{fieldSync fieldAsync}"
 
-    loop = asyncio.get_event_loop()
-
     async def get_results():
         result_promises, params = run_http_query(
             schema, "get", {}, dict(query=query), run_sync=False
@@ -54,10 +52,7 @@ def test_get_responses_using_asyncio_executor():
         res = [await result for result in result_promises]
         return res, params
 
-    try:
-        results, params = loop.run_until_complete(get_results())
-    finally:
-        loop.close()
+    results, params = asyncio.run(get_results())
 
     expected_results = [
         {"data": {"fieldSync": "sync", "fieldAsync": "async"}, "errors": None}

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,10 +1,6 @@
 import asyncio
 
-from graphql.type.definition import (
-    GraphQLField,
-    GraphQLNonNull,
-    GraphQLObjectType,
-)
+from graphql.type.definition import GraphQLField, GraphQLNonNull, GraphQLObjectType
 from graphql.type.scalars import GraphQLString
 from graphql.type.schema import GraphQLSchema
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
 envlist =
     black,flake8,import-order,mypy,manifest,
-    py{36,37,38,39,310}
+    py{37,38,39,310,311}
 ; requires = tox-conda
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 conda_channels = conda-forge
@@ -23,35 +23,35 @@ whitelist_externals =
     python
 commands =
     pip install -U setuptools
-    py{36,37,39}: pytest tests {posargs}
-    py{38}: pytest tests --cov-report=term-missing --cov=graphql_server {posargs}
+    py{37,38,39,311}: pytest tests {posargs}
+    py{310}: pytest tests --cov-report=term-missing --cov=graphql_server {posargs}
 
 [testenv:black]
-basepython = python3.9
+basepython = python3.10
 deps = -e.[dev]
 commands =
     black --check graphql_server tests
 
 [testenv:flake8]
-basepython = python3.9
+basepython = python3.10
 deps = -e.[dev]
 commands =
     flake8 setup.py graphql_server tests
 
 [testenv:import-order]
-basepython = python3.9
+basepython = python3.10
 deps = -e.[dev]
 commands =
     isort graphql_server/ tests/
 
 [testenv:mypy]
-basepython = python3.9
+basepython = python3.10
 deps = -e.[dev]
 commands =
     mypy graphql_server tests --ignore-missing-imports
 
 [testenv:manifest]
-basepython = python3.9
+basepython = python3.10
 deps = -e.[dev]
 commands =
     check-manifest -v


### PR DESCRIPTION
Update dependencies so that the package works with the latest framework versions in preparation for a stable v3 release. See #96 for context.

The PR's been rebased for convenient commit by commit review.

From `sanic` `v21` [`view`](https://sanic.dev/en/guide/advanced/class-based-views.html) now requires defining the method `get`, `post`, ... independently otherwise will throw `405`, thus the current approach of overriding `dispatch_request` won't work. The workaround is to just assign the individual method to `dispatch_request`

```python
async def __handle_request(self, request, ...): ... # previously dispatch_request

get = post = put = head = options = patch = delete = __handle_request
```

Close #86
Close #92
Close #94
Close #98

Supersede #87, #89, #91, #95.

@erikwrede