### PR TITLE
feat: add support for async schema in flask

### DIFF
--- a/graphql_server/flask/graphqlview.py
+++ b/graphql_server/flask/graphqlview.py
@@ -27,6 +27,7 @@ from graphql_server.render_graphiql import (
     GraphiQLOptions,
     render_graphiql_sync,
 )
+from graphql_server.utils import wrap_in_async
 
 
 class GraphQLView(View):
@@ -126,7 +127,7 @@ class GraphQLView(View):
                     *(
                         ex
                         if ex is not None and is_awaitable(ex)
-                        else asyncio.coroutine(lambda: ex)()
+                        else wrap_in_async(lambda: ex)()
                         for ex in execution_results
                     )
                 )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ install_flask_requires = [
     "flask>=1,<3",
 ]
 
+install_flask_async_requires = [
+    "flask[async]>=2,<3",
+]
+
 install_sanic_requires = [
     "sanic>=21.12,<23",
 ]
@@ -43,7 +47,7 @@ install_quart_requires = ["quart>=0.15,<1"]
 
 install_all_requires = (
     install_requires
-    + install_flask_requires
+    + install_flask_async_requires
     + install_sanic_requires
     + install_webob_requires
     + install_aiohttp_requires

--- a/tests/flask/app.py
+++ b/tests/flask/app.py
@@ -4,11 +4,13 @@ from graphql_server.flask import GraphQLView
 from tests.flask.schema import Schema
 
 
-def create_app(path="/graphql", **kwargs):
+def create_app(path="/graphql", schema=Schema, **kwargs):
     server = Flask(__name__)
     server.debug = True
+    view_cls = GraphQLView
     server.add_url_rule(
-        path, view_func=GraphQLView.as_view("graphql", schema=Schema, **kwargs)
+        path,
+        view_func=view_cls.as_view("graphql", schema=schema, **kwargs),
     )
     return server
 

--- a/tests/flask/schema.py
+++ b/tests/flask/schema.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from graphql.type.definition import (
     GraphQLArgument,
     GraphQLField,
@@ -49,3 +51,29 @@ MutationRootType = GraphQLObjectType(
 )
 
 Schema = GraphQLSchema(QueryRootType, MutationRootType)
+
+
+async def resolver_field_async_1(_obj, info):
+    await asyncio.sleep(0.001)
+    return "hey"
+
+
+async def resolver_field_async_2(_obj, info):
+    await asyncio.sleep(0.003)
+    return "hey2"
+
+
+def resolver_field_sync(_obj, info):
+    return "hey3"
+
+
+AsyncQueryType = GraphQLObjectType(
+    name="AsyncQueryType",
+    fields={
+        "a": GraphQLField(GraphQLString, resolve=resolver_field_async_1),
+        "b": GraphQLField(GraphQLString, resolve=resolver_field_async_2),
+        "c": GraphQLField(GraphQLString, resolve=resolver_field_sync),
+    },
+)
+
+AsyncSchema = GraphQLSchema(AsyncQueryType)

--- a/tests/flask/test_graphqlview.py
+++ b/tests/flask/test_graphqlview.py
@@ -7,6 +7,7 @@ from flask import url_for
 
 from ..utils import RepeatExecutionContext
 from .app import create_app
+from .schema import AsyncSchema
 
 
 def url_string(app, **url_params):
@@ -574,3 +575,11 @@ def test_custom_execution_context_class(app, client):
 
     assert response.status_code == 200
     assert response_json(response) == {"data": {"test": "Hello WorldHello World"}}
+
+
+@pytest.mark.parametrize("app", [create_app(schema=AsyncSchema, enable_async=True)])
+def test_async_schema(app, client):
+    response = client.get(url_string(app, query="{a,b,c}"))
+
+    assert response.status_code == 200
+    assert response_json(response) == {"data": {"a": "hey", "b": "hey2", "c": "hey3"}}


### PR DESCRIPTION
Supersede #66.

#66 implements async schema support for flask 1.0 by opening a hook to await for asynchronous execution results with `asyncio.run`. Flask 2.0 brought [async/await support](https://flask.palletsprojects.com/en/2.2.x/async-await/) and provides similar hook in [`flask.Flask.ensure_sync`](https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.ensure_sync) which this PR uses instead. See sections [extensions](https://flask.palletsprojects.com/en/2.2.x/async-await/#extensions) and [other event loops](https://flask.palletsprojects.com/en/2.2.x/async-await/#other-event-loops) in the Flask async/await doc.