### PR TITLE
feat: add support for rendering GraphiQL with jinja

### DIFF
--- a/docs/aiohttp.md
+++ b/docs/aiohttp.md
@@ -52,7 +52,7 @@ gql_view(request)  # <-- the instance is callable and expects a `aiohttp.web.Req
  * `root_value`: The `root_value` you want to provide to graphql `execute`.
  * `pretty`: Whether or not you want the response to be pretty printed JSON.
  * `graphiql`: If `True`, may present [GraphiQL](https://github.com/graphql/graphiql) when loaded directly from a browser (a useful tool for debugging and exploration).
- * `graphiql_version`: The graphiql version to load. Defaults to **"1.4.7"**.
+ * `graphiql_version`: The graphiql version to load. Defaults to **"2.2.0"**.
  * `graphiql_template`: Inject a Jinja template string to customize GraphiQL.
  * `graphiql_html_title`: The graphiql title to display. Defaults to **"GraphiQL"**.
  * `jinja_env`: Sets jinja environment to be used to process GraphiQL template. If Jinja’s async mode is enabled (by `enable_async=True`), uses `Template.render_async` instead of `Template.render`. If environment is not set, fallbacks to simple regex-based renderer.

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -46,9 +46,10 @@ This will add `/graphql` endpoint to your app and enable the GraphiQL IDE.
  * `root_value`: The `root_value` you want to provide to graphql `execute`.
  * `pretty`: Whether or not you want the response to be pretty printed JSON.
  * `graphiql`: If `True`, may present [GraphiQL](https://github.com/graphql/graphiql) when loaded directly from a browser (a useful tool for debugging and exploration).
- * `graphiql_version`: The graphiql version to load. Defaults to **"1.4.7"**.
+ * `graphiql_version`: The graphiql version to load. Defaults to **"2.2.0"**.
  * `graphiql_template`: Inject a Jinja template string to customize GraphiQL.
  * `graphiql_html_title`: The graphiql title to display. Defaults to **"GraphiQL"**.
+ * `jinja_env`: Sets jinja environment to be used to process GraphiQL template. If environment is not set, fallbacks to simple regex-based renderer.
  * `batch`: Set the GraphQL view as batch (for using in [Apollo-Client](http://dev.apollodata.com/core/network.html#query-batching) or [ReactRelayNetworkLayer](https://github.com/nodkz/react-relay-network-layer))
  * `middleware`: A list of graphql [middlewares](http://docs.graphene-python.org/en/latest/execution/middleware/).
  * `validation_rules`: A list of graphql validation rules.

--- a/docs/sanic.md
+++ b/docs/sanic.md
@@ -44,7 +44,7 @@ This will add `/graphql` endpoint to your app and enable the GraphiQL IDE.
  * `root_value`: The `root_value` you want to provide to graphql `execute`.
  * `pretty`: Whether or not you want the response to be pretty printed JSON.
  * `graphiql`: If `True`, may present [GraphiQL](https://github.com/graphql/graphiql) when loaded directly from a browser (a useful tool for debugging and exploration).
- * `graphiql_version`: The graphiql version to load. Defaults to **"1.4.7"**.
+ * `graphiql_version`: The graphiql version to load. Defaults to **"2.2.0"**.
  * `graphiql_template`: Inject a Jinja template string to customize GraphiQL.
  * `graphiql_html_title`: The graphiql title to display. Defaults to **"GraphiQL"**.
  * `jinja_env`: Sets jinja environment to be used to process GraphiQL template. If Jinja’s async mode is enabled (by `enable_async=True`), uses `Template.render_async` instead of `Template.render`. If environment is not set, fallbacks to simple regex-based renderer.

--- a/docs/webob.md
+++ b/docs/webob.md
@@ -43,9 +43,10 @@ This will add `/graphql` endpoint to your app and enable the GraphiQL IDE.
  * `root_value`: The `root_value` you want to provide to graphql `execute`.
  * `pretty`: Whether or not you want the response to be pretty printed JSON.
  * `graphiql`: If `True`, may present [GraphiQL](https://github.com/graphql/graphiql) when loaded directly from a browser (a useful tool for debugging and exploration).
- * `graphiql_version`: The graphiql version to load. Defaults to **"1.4.7"**.
+ * `graphiql_version`: The graphiql version to load. Defaults to **"2.2.0"**.
  * `graphiql_template`: Inject a Jinja template string to customize GraphiQL.
  * `graphiql_html_title`: The graphiql title to display. Defaults to **"GraphiQL"**.
+ * `jinja_env`: Sets jinja environment to be used to process GraphiQL template. If environment is not set, fallbacks to simple regex-based renderer.
  * `batch`: Set the GraphQL view as batch (for using in [Apollo-Client](http://dev.apollodata.com/core/network.html#query-batching) or [ReactRelayNetworkLayer](https://github.com/nodkz/react-relay-network-layer))
  * `middleware`: A list of graphql [middlewares](http://docs.graphene-python.org/en/latest/execution/middleware/).
  * `validation_rules`: A list of graphql validation rules.

--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -340,12 +340,12 @@ def format_execution_result(
 def _check_jinja(jinja_env: Any) -> None:
     try:
         from jinja2 import Environment
-    except ImportError:
+    except ImportError:  # pragma: no cover
         raise RuntimeError(
             "Attempt to set 'jinja_env' to a value other than None while Jinja2 is not installed.\n"
             "Please install Jinja2 to render GraphiQL with Jinja2.\n"
             "Otherwise set 'jinja_env' to None to use the simple regex renderer."
         )
 
-    if not isinstance(jinja_env, Environment):
+    if not isinstance(jinja_env, Environment):  # pragma: no cover
         raise TypeError("'jinja_env' has to be of type jinja2.Environment.")

--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -335,3 +335,17 @@ def format_execution_result(
             response = {"data": execution_result.data}
 
     return FormattedResult(response, status_code)
+
+
+def _check_jinja(jinja_env: Any) -> None:
+    try:
+        from jinja2 import Environment
+    except ImportError:
+        raise RuntimeError(
+            "Attempt to set 'jinja_env' to a value other than None while Jinja2 is not installed.\n"
+            "Please install Jinja2 to render GraphiQL with Jinja2.\n"
+            "Otherwise set 'jinja_env' to None to use the simple regex renderer."
+        )
+
+    if not isinstance(jinja_env, Environment):
+        raise TypeError("'jinja_env' has to be of type jinja2.Environment.")

--- a/graphql_server/aiohttp/graphqlview.py
+++ b/graphql_server/aiohttp/graphqlview.py
@@ -12,6 +12,7 @@ from graphql.type.schema import GraphQLSchema
 from graphql_server import (
     GraphQLParams,
     HttpQueryError,
+    _check_jinja,
     encode_execution_results,
     format_error_default,
     json_encode,
@@ -65,6 +66,9 @@ class GraphQLView:
             self.schema = getattr(self.schema, "graphql_schema", None)
             if not isinstance(self.schema, GraphQLSchema):
                 raise TypeError("A Schema is required to be provided to GraphQLView.")
+
+        if self.jinja_env is not None:
+            _check_jinja(self.jinja_env)
 
     def get_root_value(self):
         return self.root_value

--- a/graphql_server/flask/graphqlview.py
+++ b/graphql_server/flask/graphqlview.py
@@ -12,6 +12,7 @@ from graphql.type.schema import GraphQLSchema
 from graphql_server import (
     GraphQLParams,
     HttpQueryError,
+    _check_jinja,
     encode_execution_results,
     format_error_default,
     json_encode,
@@ -62,6 +63,9 @@ class GraphQLView(View):
             self.schema = getattr(self.schema, "graphql_schema", None)
             if not isinstance(self.schema, GraphQLSchema):
                 raise TypeError("A Schema is required to be provided to GraphQLView.")
+
+        if self.jinja_env is not None:
+            _check_jinja(self.jinja_env)
 
     def get_root_value(self):
         return self.root_value

--- a/graphql_server/flask/graphqlview.py
+++ b/graphql_server/flask/graphqlview.py
@@ -39,6 +39,7 @@ class GraphQLView(View):
     validation_rules = None
     execution_context_class = None
     batch = False
+    jinja_env = None
     subscriptions = None
     headers = None
     default_query = None
@@ -131,7 +132,7 @@ class GraphQLView(View):
                     graphiql_version=self.graphiql_version,
                     graphiql_template=self.graphiql_template,
                     graphiql_html_title=self.graphiql_html_title,
-                    jinja_env=None,
+                    jinja_env=self.jinja_env,
                 )
                 graphiql_options = GraphiQLOptions(
                     default_query=self.default_query,

--- a/graphql_server/quart/graphqlview.py
+++ b/graphql_server/quart/graphqlview.py
@@ -42,6 +42,7 @@ class GraphQLView(View):
     validation_rules = None
     execution_context_class = None
     batch = False
+    jinja_env = None
     enable_async = False
     subscriptions = None
     headers = None
@@ -147,7 +148,7 @@ class GraphQLView(View):
                     graphiql_version=self.graphiql_version,
                     graphiql_template=self.graphiql_template,
                     graphiql_html_title=self.graphiql_html_title,
-                    jinja_env=None,
+                    jinja_env=self.jinja_env,
                 )
                 graphiql_options = GraphiQLOptions(
                     default_query=self.default_query,

--- a/graphql_server/quart/graphqlview.py
+++ b/graphql_server/quart/graphqlview.py
@@ -14,6 +14,7 @@ from quart.views import View
 from graphql_server import (
     GraphQLParams,
     HttpQueryError,
+    _check_jinja,
     encode_execution_results,
     format_error_default,
     json_encode,
@@ -66,6 +67,9 @@ class GraphQLView(View):
             self.schema = getattr(self.schema, "graphql_schema", None)
             if not isinstance(self.schema, GraphQLSchema):
                 raise TypeError("A Schema is required to be provided to GraphQLView.")
+
+        if self.jinja_env is not None:
+            _check_jinja(self.jinja_env)
 
     def get_root_value(self):
         return self.root_value

--- a/graphql_server/render_graphiql.py
+++ b/graphql_server/render_graphiql.py
@@ -4,7 +4,11 @@ import json
 import re
 from typing import Any, Dict, Optional, Tuple
 
-from jinja2 import Environment
+try:
+    from jinja2 import Environment
+except ImportError:
+    pass
+
 from typing_extensions import TypedDict
 
 GRAPHIQL_VERSION = "2.2.0"

--- a/graphql_server/render_graphiql.py
+++ b/graphql_server/render_graphiql.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 # and only relevant if rendering GraphiQL with Jinja
 try:
     from jinja2 import Environment
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 from typing_extensions import TypedDict

--- a/graphql_server/render_graphiql.py
+++ b/graphql_server/render_graphiql.py
@@ -4,6 +4,8 @@ import json
 import re
 from typing import Any, Dict, Optional, Tuple
 
+# This Environment import is only for type checking purpose,
+# and only relevant if rendering GraphiQL with Jinja
 try:
     from jinja2 import Environment
 except ImportError:

--- a/graphql_server/sanic/graphqlview.py
+++ b/graphql_server/sanic/graphqlview.py
@@ -14,6 +14,7 @@ from sanic.views import HTTPMethodView
 from graphql_server import (
     GraphQLParams,
     HttpQueryError,
+    _check_jinja,
     encode_execution_results,
     format_error_default,
     json_encode,
@@ -67,6 +68,9 @@ class GraphQLView(HTTPMethodView):
             self.schema = getattr(self.schema, "graphql_schema", None)
             if not isinstance(self.schema, GraphQLSchema):
                 raise TypeError("A Schema is required to be provided to GraphQLView.")
+
+        if self.jinja_env is not None:
+            _check_jinja(self.jinja_env)
 
     def get_root_value(self):
         return self.root_value

--- a/graphql_server/utils.py
+++ b/graphql_server/utils.py
@@ -3,7 +3,7 @@ from typing import Awaitable, Callable, TypeVar
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
-else:
+else:  # pragma: no cover
     from typing_extensions import ParamSpec
 
 

--- a/graphql_server/webob/graphqlview.py
+++ b/graphql_server/webob/graphqlview.py
@@ -38,6 +38,7 @@ class GraphQLView:
     validation_rules = None
     execution_context_class = None
     batch = False
+    jinja_env = None
     enable_async = False
     subscriptions = None
     headers = None
@@ -133,7 +134,7 @@ class GraphQLView:
                     graphiql_version=self.graphiql_version,
                     graphiql_template=self.graphiql_template,
                     graphiql_html_title=self.graphiql_html_title,
-                    jinja_env=None,
+                    jinja_env=self.jinja_env,
                 )
                 graphiql_options = GraphiQLOptions(
                     default_query=self.default_query,

--- a/graphql_server/webob/graphqlview.py
+++ b/graphql_server/webob/graphqlview.py
@@ -11,6 +11,7 @@ from webob import Response
 from graphql_server import (
     GraphQLParams,
     HttpQueryError,
+    _check_jinja,
     encode_execution_results,
     format_error_default,
     json_encode,
@@ -61,6 +62,9 @@ class GraphQLView:
             self.schema = getattr(self.schema, "graphql_schema", None)
             if not isinstance(self.schema, GraphQLSchema):
                 raise TypeError("A Schema is required to be provided to GraphQLView.")
+
+        if self.jinja_env is not None:
+            _check_jinja(self.jinja_env)
 
     def get_root_value(self):
         return self.root_value

--- a/tests/aiohttp/app.py
+++ b/tests/aiohttp/app.py
@@ -3,7 +3,8 @@ from urllib.parse import urlencode
 from aiohttp import web
 
 from graphql_server.aiohttp import GraphQLView
-from tests.aiohttp.schema import Schema
+
+from .schema import Schema
 
 
 def create_app(schema=Schema, **kwargs):
@@ -13,10 +14,5 @@ def create_app(schema=Schema, **kwargs):
     return app
 
 
-def url_string(**url_params):
-    base_url = "/graphql"
-
-    if url_params:
-        return f"{base_url}?{urlencode(url_params)}"
-
-    return base_url
+def url_string(url="/graphql", **url_params):
+    return f"{url}?{urlencode(url_params)}" if url_params else url

--- a/tests/aiohttp/conftest.py
+++ b/tests/aiohttp/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from .app import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    yield client
+    await client.close()

--- a/tests/aiohttp/test_graphqlview.py
+++ b/tests/aiohttp/test_graphqlview.py
@@ -2,27 +2,11 @@ import json
 from urllib.parse import urlencode
 
 import pytest
-import pytest_asyncio
 from aiohttp import FormData
-from aiohttp.test_utils import TestClient, TestServer
 
 from ..utils import RepeatExecutionContext
 from .app import create_app, url_string
 from .schema import AsyncSchema
-
-
-@pytest.fixture
-def app():
-    app = create_app()
-    return app
-
-
-@pytest_asyncio.fixture
-async def client(app):
-    client = TestClient(TestServer(app))
-    await client.start_server()
-    yield client
-    await client.close()
 
 
 @pytest.mark.asyncio

--- a/tests/flask/conftest.py
+++ b/tests/flask/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+from .app import create_app
+
+
+@pytest.fixture
+def app():
+    # import app factory pattern
+    app = create_app()
+
+    # pushes an application context manually
+    ctx = app.app_context()
+    ctx.push()
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/flask/test_graphiqlview.py
+++ b/tests/flask/test_graphiqlview.py
@@ -1,25 +1,14 @@
 import pytest
 from flask import url_for
+from jinja2 import Environment
 
 from .app import create_app
 
 
-@pytest.fixture
-def app():
-    # import app factory pattern
-    app = create_app(graphiql=True)
-
-    # pushes an application context manually
-    ctx = app.app_context()
-    ctx.push()
-    return app
-
-
-@pytest.fixture
-def client(app):
-    return app.test_client()
-
-
+@pytest.mark.parametrize(
+    "app",
+    [create_app(graphiql=True), create_app(graphiql=True, jinja_env=Environment())],
+)
 def test_graphiql_is_enabled(app, client):
     with app.test_request_context():
         response = client.get(
@@ -28,6 +17,10 @@ def test_graphiql_is_enabled(app, client):
     assert response.status_code == 200
 
 
+@pytest.mark.parametrize(
+    "app",
+    [create_app(graphiql=True), create_app(graphiql=True, jinja_env=Environment())],
+)
 def test_graphiql_renders_pretty(app, client):
     with app.test_request_context():
         response = client.get(
@@ -45,6 +38,10 @@ def test_graphiql_renders_pretty(app, client):
     assert pretty_response in response.data.decode("utf-8")
 
 
+@pytest.mark.parametrize(
+    "app",
+    [create_app(graphiql=True), create_app(graphiql=True, jinja_env=Environment())],
+)
 def test_graphiql_default_title(app, client):
     with app.test_request_context():
         response = client.get(url_for("graphql"), headers={"Accept": "text/html"})
@@ -52,7 +49,13 @@ def test_graphiql_default_title(app, client):
 
 
 @pytest.mark.parametrize(
-    "app", [create_app(graphiql=True, graphiql_html_title="Awesome")]
+    "app",
+    [
+        create_app(graphiql=True, graphiql_html_title="Awesome"),
+        create_app(
+            graphiql=True, graphiql_html_title="Awesome", jinja_env=Environment()
+        ),
+    ],
 )
 def test_graphiql_custom_title(app, client):
     with app.test_request_context():

--- a/tests/flask/test_graphqlview.py
+++ b/tests/flask/test_graphqlview.py
@@ -9,30 +9,11 @@ from ..utils import RepeatExecutionContext
 from .app import create_app
 
 
-@pytest.fixture
-def app():
-    # import app factory pattern
-    app = create_app()
-
-    # pushes an application context manually
-    ctx = app.app_context()
-    ctx.push()
-    return app
-
-
-@pytest.fixture
-def client(app):
-    return app.test_client()
-
-
 def url_string(app, **url_params):
     with app.test_request_context():
-        string = url_for("graphql")
+        url = url_for("graphql")
 
-    if url_params:
-        string += "?" + urlencode(url_params)
-
-    return string
+    return f"{url}?{urlencode(url_params)}" if url_params else url
 
 
 def response_json(response):

--- a/tests/quart/conftest.py
+++ b/tests/quart/conftest.py
@@ -1,3 +1,23 @@
+import pytest
+from quart import Quart
 from quart.typing import TestClientProtocol
 
+from .app import create_app
+
 TestClientProtocol.__test__ = False  # type: ignore
+
+
+@pytest.fixture
+def app() -> Quart:
+    # import app factory pattern
+    app = create_app()
+
+    # pushes an application context manually
+    # ctx = app.app_context()
+    # await ctx.push()
+    return app
+
+
+@pytest.fixture
+def client(app: Quart) -> TestClientProtocol:
+    return app.test_client()

--- a/tests/quart/test_graphiqlview.py
+++ b/tests/quart/test_graphiqlview.py
@@ -1,27 +1,12 @@
 from typing import Optional
 
 import pytest
+from jinja2 import Environment
 from quart import Quart, Response, url_for
 from quart.typing import TestClientProtocol
 from werkzeug.datastructures import Headers
 
 from .app import create_app
-
-
-@pytest.fixture
-def app() -> Quart:
-    # import app factory pattern
-    app = create_app(graphiql=True)
-
-    # pushes an application context manually
-    # ctx = app.app_context()
-    # await ctx.push()
-    return app
-
-
-@pytest.fixture
-def client(app: Quart) -> TestClientProtocol:
-    return app.test_client()
 
 
 @pytest.mark.asyncio
@@ -39,6 +24,10 @@ async def execute_client(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "app",
+    [create_app(graphiql=True), create_app(graphiql=True, jinja_env=Environment())],
+)
 async def test_graphiql_is_enabled(app: Quart, client: TestClientProtocol):
     response = await execute_client(
         app, client, headers=Headers({"Accept": "text/html"}), externals=False
@@ -47,6 +36,10 @@ async def test_graphiql_is_enabled(app: Quart, client: TestClientProtocol):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "app",
+    [create_app(graphiql=True), create_app(graphiql=True, jinja_env=Environment())],
+)
 async def test_graphiql_renders_pretty(app: Quart, client: TestClientProtocol):
     response = await execute_client(
         app, client, headers=Headers({"Accept": "text/html"}), query="{test}"
@@ -64,6 +57,10 @@ async def test_graphiql_renders_pretty(app: Quart, client: TestClientProtocol):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "app",
+    [create_app(graphiql=True), create_app(graphiql=True, jinja_env=Environment())],
+)
 async def test_graphiql_default_title(app: Quart, client: TestClientProtocol):
     response = await execute_client(
         app, client, headers=Headers({"Accept": "text/html"})
@@ -74,7 +71,13 @@ async def test_graphiql_default_title(app: Quart, client: TestClientProtocol):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "app", [create_app(graphiql=True, graphiql_html_title="Awesome")]
+    "app",
+    [
+        create_app(graphiql=True, graphiql_html_title="Awesome"),
+        create_app(
+            graphiql=True, graphiql_html_title="Awesome", jinja_env=Environment()
+        ),
+    ],
 )
 async def test_graphiql_custom_title(app: Quart, client: TestClientProtocol):
     response = await execute_client(

--- a/tests/quart/test_graphqlview.py
+++ b/tests/quart/test_graphqlview.py
@@ -12,22 +12,6 @@ from .app import create_app
 from .schema import AsyncSchema
 
 
-@pytest.fixture
-def app() -> Quart:
-    # import app factory pattern
-    app = create_app(graphiql=True)
-
-    # pushes an application context manually
-    # ctx = app.app_context()
-    # await ctx.push()
-    return app
-
-
-@pytest.fixture
-def client(app: Quart) -> TestClientProtocol:
-    return app.test_client()
-
-
 @pytest.mark.asyncio
 async def execute_client(
     app: Quart,

--- a/tests/sanic/app.py
+++ b/tests/sanic/app.py
@@ -17,5 +17,5 @@ def create_app(path="/graphql", schema=Schema, **kwargs):
     return app
 
 
-def url_string(uri="/graphql", **url_params):
-    return f"{uri}?{urlencode(url_params)}" if url_params else uri
+def url_string(url="/graphql", **url_params):
+    return f"{url}?{urlencode(url_params)}" if url_params else url

--- a/tests/sanic/app.py
+++ b/tests/sanic/app.py
@@ -8,20 +8,14 @@ from graphql_server.sanic import GraphQLView
 from .schema import Schema
 
 
-def create_app(path="/graphql", **kwargs):
+def create_app(path="/graphql", schema=Schema, **kwargs):
     random_valid_app_name = f"App{uuid.uuid4().hex}"
     app = Sanic(random_valid_app_name)
 
-    schema = kwargs.pop("schema", None) or Schema
     app.add_route(GraphQLView.as_view(schema=schema, **kwargs), path)
 
     return app
 
 
 def url_string(uri="/graphql", **url_params):
-    string = "/graphql"
-
-    if url_params:
-        string += "?" + urlencode(url_params)
-
-    return string
+    return f"{uri}?{urlencode(url_params)}" if url_params else uri

--- a/tests/sanic/conftest.py
+++ b/tests/sanic/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from .app import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app()

--- a/tests/sanic/test_graphiqlview.py
+++ b/tests/sanic/test_graphiqlview.py
@@ -5,9 +5,22 @@ from .app import create_app, url_string
 from .schema import AsyncSchema, SyncSchema
 
 
-@pytest.fixture
-def pretty_response():
-    return (
+@pytest.mark.parametrize(
+    "app",
+    [
+        create_app(graphiql=True),
+        create_app(graphiql=True, jinja_env=Environment()),
+        create_app(graphiql=True, jinja_env=Environment(enable_async=True)),
+    ],
+)
+def test_graphiql_is_enabled(app):
+    _, response = app.test_client.get(
+        uri=url_string(query="{test}"), headers={"Accept": "text/html"}
+    )
+
+    assert response.status == 200
+
+    pretty_response = (
         "{\n"
         '  "data": {\n'
         '    "test": "Hello World"\n'
@@ -15,41 +28,6 @@ def pretty_response():
         "}".replace('"', '\\"').replace("\n", "\\n")
     )
 
-
-@pytest.mark.parametrize("app", [create_app(graphiql=True)])
-def test_graphiql_is_enabled(app):
-    _, response = app.test_client.get(
-        uri=url_string(query="{test}"), headers={"Accept": "text/html"}
-    )
-    assert response.status == 200
-
-
-@pytest.mark.parametrize("app", [create_app(graphiql=True)])
-def test_graphiql_simple_renderer(app, pretty_response):
-    _, response = app.test_client.get(
-        uri=url_string(query="{test}"), headers={"Accept": "text/html"}
-    )
-    assert response.status == 200
-    assert pretty_response in response.body.decode("utf-8")
-
-
-@pytest.mark.parametrize("app", [create_app(graphiql=True, jinja_env=Environment())])
-def test_graphiql_jinja_renderer(app, pretty_response):
-    _, response = app.test_client.get(
-        uri=url_string(query="{test}"), headers={"Accept": "text/html"}
-    )
-    assert response.status == 200
-    assert pretty_response in response.body.decode("utf-8")
-
-
-@pytest.mark.parametrize(
-    "app", [create_app(graphiql=True, jinja_env=Environment(enable_async=True))]
-)
-def test_graphiql_jinja_async_renderer(app, pretty_response):
-    _, response = app.test_client.get(
-        uri=url_string(query="{test}"), headers={"Accept": "text/html"}
-    )
-    assert response.status == 200
     assert pretty_response in response.body.decode("utf-8")
 
 

--- a/tests/sanic/test_graphqlview.py
+++ b/tests/sanic/test_graphqlview.py
@@ -20,7 +20,6 @@ def json_dump_kwarg_list(**kwargs):
     return json.dumps([kwargs])
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_allows_get_with_query_param(app):
     _, response = app.test_client.get(uri=url_string(query="{test}"))
 
@@ -28,7 +27,6 @@ def test_allows_get_with_query_param(app):
     assert response_json(response) == {"data": {"test": "Hello World"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_allows_get_with_variable_values(app):
     _, response = app.test_client.get(
         uri=url_string(
@@ -41,7 +39,6 @@ def test_allows_get_with_variable_values(app):
     assert response_json(response) == {"data": {"test": "Hello Dolly"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_allows_get_with_operation_name(app):
     _, response = app.test_client.get(
         uri=url_string(
@@ -63,7 +60,6 @@ def test_allows_get_with_operation_name(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_reports_validation_errors(app):
     _, response = app.test_client.get(
         uri=url_string(query="{ test, unknownOne, unknownTwo }")
@@ -84,7 +80,6 @@ def test_reports_validation_errors(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_errors_when_missing_operation_name(app):
     _, response = app.test_client.get(
         uri=url_string(
@@ -106,7 +101,6 @@ def test_errors_when_missing_operation_name(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_errors_when_sending_a_mutation_via_get(app):
     _, response = app.test_client.get(
         uri=url_string(
@@ -125,7 +119,6 @@ def test_errors_when_sending_a_mutation_via_get(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_errors_when_selecting_a_mutation_within_a_get(app):
     _, response = app.test_client.get(
         uri=url_string(
@@ -147,7 +140,6 @@ def test_errors_when_selecting_a_mutation_within_a_get(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_allows_mutation_to_exist_within_a_get(app):
     _, response = app.test_client.get(
         uri=url_string(
@@ -163,7 +155,6 @@ def test_allows_mutation_to_exist_within_a_get(app):
     assert response_json(response) == {"data": {"test": "Hello World"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_allows_post_with_json_encoding(app):
     _, response = app.test_client.post(
         uri=url_string(),
@@ -175,7 +166,6 @@ def test_allows_post_with_json_encoding(app):
     assert response_json(response) == {"data": {"test": "Hello World"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_allows_sending_a_mutation_via_post(app):
     _, response = app.test_client.post(
         uri=url_string(),
@@ -187,7 +177,6 @@ def test_allows_sending_a_mutation_via_post(app):
     assert response_json(response) == {"data": {"writeTest": {"test": "Hello World"}}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_allows_post_with_url_encoding(app):
     # Example of how sanic does send data using url enconding
     # can be found at their repo.
@@ -203,7 +192,6 @@ def test_allows_post_with_url_encoding(app):
     assert response_json(response) == {"data": {"test": "Hello World"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_json_query_with_string_variables(app):
     _, response = app.test_client.post(
         uri=url_string(),
@@ -218,7 +206,6 @@ def test_supports_post_json_query_with_string_variables(app):
     assert response_json(response) == {"data": {"test": "Hello Dolly"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_json_query_with_json_variables(app):
     _, response = app.test_client.post(
         uri=url_string(),
@@ -233,7 +220,6 @@ def test_supports_post_json_query_with_json_variables(app):
     assert response_json(response) == {"data": {"test": "Hello Dolly"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_url_encoded_query_with_string_variables(app):
     _, response = app.test_client.post(
         uri=url_string(),
@@ -250,7 +236,6 @@ def test_supports_post_url_encoded_query_with_string_variables(app):
     assert response_json(response) == {"data": {"test": "Hello Dolly"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_json_query_with_get_variable_values(app):
     _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
@@ -264,7 +249,6 @@ def test_supports_post_json_query_with_get_variable_values(app):
     assert response_json(response) == {"data": {"test": "Hello Dolly"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_post_url_encoded_query_with_get_variable_values(app):
     _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
@@ -280,7 +264,6 @@ def test_post_url_encoded_query_with_get_variable_values(app):
     assert response_json(response) == {"data": {"test": "Hello Dolly"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_supports_post_raw_text_query_with_get_variable_values(app):
     _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
@@ -292,7 +275,6 @@ def test_supports_post_raw_text_query_with_get_variable_values(app):
     assert response_json(response) == {"data": {"test": "Hello Dolly"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_allows_post_with_operation_name(app):
     _, response = app.test_client.post(
         uri=url_string(),
@@ -316,7 +298,6 @@ def test_allows_post_with_operation_name(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_allows_post_with_get_operation_name(app):
     _, response = app.test_client.post(
         uri=url_string(operationName="helloWorld"),
@@ -353,7 +334,6 @@ def test_not_pretty_by_default(app):
     assert response.body.decode() == '{"data":{"test":"Hello World"}}'
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_supports_pretty_printing_by_request(app):
     _, response = app.test_client.get(uri=url_string(query="{test}", pretty="1"))
 
@@ -362,7 +342,6 @@ def test_supports_pretty_printing_by_request(app):
     )
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_handles_field_errors_caught_by_graphql(app):
     _, response = app.test_client.get(uri=url_string(query="{thrower}"))
     assert response.status == 200
@@ -378,7 +357,6 @@ def test_handles_field_errors_caught_by_graphql(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_handles_syntax_errors_caught_by_graphql(app):
     _, response = app.test_client.get(uri=url_string(query="syntaxerror"))
     assert response.status == 400
@@ -392,7 +370,6 @@ def test_handles_syntax_errors_caught_by_graphql(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_handles_errors_caused_by_a_lack_of_query(app):
     _, response = app.test_client.get(uri=url_string())
 
@@ -402,7 +379,6 @@ def test_handles_errors_caused_by_a_lack_of_query(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_handles_batch_correctly_if_is_disabled(app):
     _, response = app.test_client.post(
         uri=url_string(), content="[]", headers={"content-type": "application/json"}
@@ -418,7 +394,6 @@ def test_handles_batch_correctly_if_is_disabled(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_handles_incomplete_json_bodies(app):
     _, response = app.test_client.post(
         uri=url_string(),
@@ -432,7 +407,6 @@ def test_handles_incomplete_json_bodies(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_handles_plain_post_text(app):
     _, response = app.test_client.post(
         uri=url_string(variables=json.dumps({"who": "Dolly"})),
@@ -445,7 +419,6 @@ def test_handles_plain_post_text(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_handles_poorly_formed_variables(app):
     _, response = app.test_client.get(
         uri=url_string(
@@ -458,7 +431,6 @@ def test_handles_poorly_formed_variables(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_handles_unsupported_http_methods(app):
     _, response = app.test_client.put(uri=url_string(query="{test}"))
     assert response.status == 405
@@ -475,7 +447,6 @@ def test_handles_unsupported_http_methods(app):
     }
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_passes_request_into_request_context(app):
     _, response = app.test_client.get(uri=url_string(query="{request}", q="testing"))
 
@@ -513,7 +484,6 @@ def test_context_remapped_if_not_mapping(app):
     assert "Request" in res["data"]["context"]["request"]
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_post_multipart_data(app):
     query = "mutation TestMutation { writeTest { test } }"
 
@@ -603,7 +573,6 @@ def test_async_schema(app):
     assert response_json(response) == {"data": {"a": "hey", "b": "hey2", "c": "hey3"}}
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_preflight_request(app):
     _, response = app.test_client.options(
         uri=url_string(), headers={"Access-Control-Request-Method": "POST"}
@@ -612,7 +581,6 @@ def test_preflight_request(app):
     assert response.status == 200
 
 
-@pytest.mark.parametrize("app", [create_app()])
 def test_preflight_incorrect_request(app):
     _, response = app.test_client.options(
         uri=url_string(), headers={"Access-Control-Request-Method": "OPTIONS"}

--- a/tests/webob/app.py
+++ b/tests/webob/app.py
@@ -3,16 +3,12 @@ from urllib.parse import urlencode
 from webob import Request
 
 from graphql_server.webob import GraphQLView
-from tests.webob.schema import Schema
+
+from .schema import Schema
 
 
-def url_string(**url_params):
-    string = "/graphql"
-
-    if url_params:
-        string += "?" + urlencode(url_params)
-
-    return string
+def url_string(url="/graphql", **url_params):
+    return f"{url}?{urlencode(url_params)}" if url_params else url
 
 
 class Client(object):

--- a/tests/webob/conftest.py
+++ b/tests/webob/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from .app import Client
+
+
+@pytest.fixture
+def settings():
+    return {}
+
+
+@pytest.fixture
+def client(settings):
+    return Client(settings=settings)

--- a/tests/webob/test_graphiqlview.py
+++ b/tests/webob/test_graphiqlview.py
@@ -1,43 +1,36 @@
 import pytest
+from jinja2 import Environment
 
-from .app import Client, url_string
-
-
-@pytest.fixture
-def settings():
-    return {}
+from .app import url_string
 
 
-@pytest.fixture
-def client(settings):
-    return Client(settings=settings)
+@pytest.mark.parametrize(
+    "settings", [dict(graphiql=True), dict(graphiql=True, jinja_env=Environment())]
+)
+def test_graphiql_is_enabled(client):
+    response = client.get(url_string(query="{test}"), headers={"Accept": "text/html"})
+    assert response.status_code == 200
 
 
-@pytest.fixture
-def pretty_response():
-    return (
+@pytest.mark.parametrize(
+    "settings", [dict(graphiql=True), dict(graphiql=True, jinja_env=Environment())]
+)
+def test_graphiql_simple_renderer(client):
+    response = client.get(url_string(query="{test}"), headers={"Accept": "text/html"})
+    assert response.status_code == 200
+    pretty_response = (
         "{\n"
         '  "data": {\n'
         '    "test": "Hello World"\n'
         "  }\n"
         "}".replace('"', '\\"').replace("\n", "\\n")
     )
-
-
-@pytest.mark.parametrize("settings", [dict(graphiql=True)])
-def test_graphiql_is_enabled(client, settings):
-    response = client.get(url_string(query="{test}"), headers={"Accept": "text/html"})
-    assert response.status_code == 200
-
-
-@pytest.mark.parametrize("settings", [dict(graphiql=True)])
-def test_graphiql_simple_renderer(client, settings, pretty_response):
-    response = client.get(url_string(query="{test}"), headers={"Accept": "text/html"})
-    assert response.status_code == 200
     assert pretty_response in response.body.decode("utf-8")
 
 
-@pytest.mark.parametrize("settings", [dict(graphiql=True)])
-def test_graphiql_html_is_not_accepted(client, settings):
+@pytest.mark.parametrize(
+    "settings", [dict(graphiql=True), dict(graphiql=True, jinja_env=Environment())]
+)
+def test_graphiql_html_is_not_accepted(client):
     response = client.get(url_string(), headers={"Accept": "application/json"})
     assert response.status_code == 400

--- a/tests/webob/test_graphqlview.py
+++ b/tests/webob/test_graphqlview.py
@@ -4,17 +4,7 @@ from urllib.parse import urlencode
 import pytest
 
 from ..utils import RepeatExecutionContext
-from .app import Client, url_string
-
-
-@pytest.fixture
-def settings():
-    return {}
-
-
-@pytest.fixture
-def client(settings):
-    return Client(settings=settings)
+from .app import url_string
 
 
 def response_json(response):


### PR DESCRIPTION
Render graphiql using jinja2 [`Template.render`](https://jinja.palletsprojects.com/en/3.1.x/api/#jinja2.Template.render) instead of regex search and replace.

Also supersede #97.