### PR TITLE
docs: add docs on integration with Graphene v3

### DIFF
--- a/docs/aiohttp.md
+++ b/docs/aiohttp.md
@@ -47,7 +47,7 @@ gql_view(request)  # <-- the instance is callable and expects a `aiohttp.web.Req
 
 ### Supported options for GraphQLView
 
- * `schema`: The `GraphQLSchema` object that you want the view to execute when it gets a valid request.
+ * `schema`: The GraphQL schema object that you want the view to execute when it gets a valid request. Accepts either an object of type `GraphQLSchema` from `graphql-core` or `Schema` from `graphene`. For Graphene v3, passing either `schema: graphene.Schema` or `schema.graphql_schema` is allowed.
  * `context`: A value to pass as the `context_value` to graphql `execute` function. By default is set to `dict` with request object at key `request`.
  * `root_value`: The `root_value` you want to provide to graphql `execute`.
  * `pretty`: Whether or not you want the response to be pretty printed JSON.

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -39,16 +39,9 @@ if __name__ == '__main__':
 
 This will add `/graphql` endpoint to your app and enable the GraphiQL IDE.
 
-### Special Note for Graphene v3
-
-If you are using the `Schema` type of [Graphene](https://github.com/graphql-python/graphene) library, be sure to use the `graphql_schema` attribute to pass as schema on the `GraphQLView` view. Otherwise, the `GraphQLSchema` from `graphql-core` is the way to go.
-
-More info at [Graphene v3 release notes](https://github.com/graphql-python/graphene/wiki/v3-release-notes#graphene-schema-no-longer-subclasses-graphqlschema-type) and [GraphQL-core 3 usage](https://github.com/graphql-python/graphql-core#usage).
-
-
 ### Supported options for GraphQLView
 
- * `schema`: The `GraphQLSchema` object that you want the view to execute when it gets a valid request.
+ * `schema`: The GraphQL schema object that you want the view to execute when it gets a valid request. Accepts either an object of type `GraphQLSchema` from `graphql-core` or `Schema` from `graphene`. For Graphene v3, passing either `schema: graphene.Schema` or `schema.graphql_schema` is allowed.
  * `context`: A value to pass as the `context_value` to graphql `execute` function. By default is set to `dict` with request object at key `request`.
  * `root_value`: The `root_value` you want to provide to graphql `execute`.
  * `pretty`: Whether or not you want the response to be pretty printed JSON.

--- a/docs/sanic.md
+++ b/docs/sanic.md
@@ -39,7 +39,7 @@ This will add `/graphql` endpoint to your app and enable the GraphiQL IDE.
 
 ### Supported options for GraphQLView
 
- * `schema`: The `GraphQLSchema` object that you want the view to execute when it gets a valid request.
+ * `schema`: The GraphQL schema object that you want the view to execute when it gets a valid request. Accepts either an object of type `GraphQLSchema` from `graphql-core` or `Schema` from `graphene`. For Graphene v3, passing either `schema: graphene.Schema` or `schema.graphql_schema` is allowed.
  * `context`: A value to pass as the `context_value` to graphql `execute` function. By default is set to `dict` with request object at key `request`.
  * `root_value`: The `root_value` you want to provide to graphql `execute`.
  * `pretty`: Whether or not you want the response to be pretty printed JSON.

--- a/docs/webob.md
+++ b/docs/webob.md
@@ -38,7 +38,7 @@ This will add `/graphql` endpoint to your app and enable the GraphiQL IDE.
 
 ### Supported options for GraphQLView
 
- * `schema`: The `GraphQLSchema` object that you want the view to execute when it gets a valid request.
+ * `schema`: The GraphQL schema object that you want the view to execute when it gets a valid request. Accepts either an object of type `GraphQLSchema` from `graphql-core` or `Schema` from `graphene`. For Graphene v3, passing either `schema: graphene.Schema` or `schema.graphql_schema` is allowed.
  * `context`: A value to pass as the `context_value` to graphql `execute` function. By default is set to `dict` with request object at key `request`.
  * `root_value`: The `root_value` you want to provide to graphql `execute`.
  * `pretty`: Whether or not you want the response to be pretty printed JSON.


### PR DESCRIPTION
Supersede #90.

Thanks to 476edf370099df050289f9c0b8d70007e7dc8ecc users can pass a `schema` object of type `graphene.Schema` to `GraphQLView` directly. This is equivalent to passing `schema.graphql_schema`