### PR TITLE
Allow empty custom context in GraphQLView

### DIFF
--- a/graphql_server/aiohttp/graphqlview.py
+++ b/graphql_server/aiohttp/graphqlview.py
@@ -69,7 +69,7 @@ class GraphQLView:
     def get_context(self, request):
         context = (
             copy.copy(self.context)
-            if self.context and isinstance(self.context, MutableMapping)
+            if self.context is not None and isinstance(self.context, MutableMapping)
             else {}
         )
         if isinstance(context, MutableMapping) and "request" not in context:

--- a/graphql_server/flask/graphqlview.py
+++ b/graphql_server/flask/graphqlview.py
@@ -68,7 +68,7 @@ class GraphQLView(View):
     def get_context(self):
         context = (
             copy.copy(self.context)
-            if self.context and isinstance(self.context, MutableMapping)
+            if self.context is not None and isinstance(self.context, MutableMapping)
             else {}
         )
         if isinstance(context, MutableMapping) and "request" not in context:

--- a/graphql_server/quart/graphqlview.py
+++ b/graphql_server/quart/graphqlview.py
@@ -69,7 +69,7 @@ class GraphQLView(View):
     def get_context(self):
         context = (
             copy.copy(self.context)
-            if self.context and isinstance(self.context, MutableMapping)
+            if self.context is not None and isinstance(self.context, MutableMapping)
             else {}
         )
         if isinstance(context, MutableMapping) and "request" not in context:

--- a/graphql_server/sanic/graphqlview.py
+++ b/graphql_server/sanic/graphqlview.py
@@ -71,7 +71,7 @@ class GraphQLView(HTTPMethodView):
     def get_context(self, request):
         context = (
             copy.copy(self.context)
-            if self.context and isinstance(self.context, MutableMapping)
+            if self.context is not None and isinstance(self.context, MutableMapping)
             else {}
         )
         if isinstance(context, MutableMapping) and "request" not in context:

--- a/graphql_server/webob/graphqlview.py
+++ b/graphql_server/webob/graphqlview.py
@@ -67,7 +67,7 @@ class GraphQLView:
     def get_context(self, request):
         context = (
             copy.copy(self.context)
-            if self.context and isinstance(self.context, MutableMapping)
+            if self.context is not None and isinstance(self.context, MutableMapping)
             else {}
         )
         if isinstance(context, MutableMapping) and "request" not in context:

--- a/tests/aiohttp/schema.py
+++ b/tests/aiohttp/schema.py
@@ -35,6 +35,10 @@ QueryRootType = GraphQLObjectType(
                         GraphQLNonNull(GraphQLString),
                         resolve=lambda obj, info: info.context["request"],
                     ),
+                    "property": GraphQLField(
+                        GraphQLString,
+                        resolve=lambda obj, info: info.context.property
+                    ),
                 },
             ),
             resolve=lambda obj, info: info.context,

--- a/tests/aiohttp/schema.py
+++ b/tests/aiohttp/schema.py
@@ -36,8 +36,7 @@ QueryRootType = GraphQLObjectType(
                         resolve=lambda obj, info: info.context["request"],
                     ),
                     "property": GraphQLField(
-                        GraphQLString,
-                        resolve=lambda obj, info: info.context.property
+                        GraphQLString, resolve=lambda obj, info: info.context.property
                     ),
                 },
             ),

--- a/tests/aiohttp/test_graphqlview.py
+++ b/tests/aiohttp/test_graphqlview.py
@@ -555,6 +555,24 @@ async def test_context_remapped_if_not_mapping(app, client):
     assert "Request" in _json["data"]["context"]["request"]
 
 
+class CustomContext(dict):
+    property = "A custom property"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("app", [create_app(context=CustomContext())])
+async def test_allow_empty_custom_context(app, client):
+    response = await client.get(url_string(query="{context { property request }}"))
+
+    _json = await response.json()
+    assert response.status == 200
+    assert "data" in _json
+    assert "request" in _json["data"]["context"]
+    assert "property" in _json["data"]["context"]
+    assert "A custom property" == _json["data"]["context"]["property"]
+    assert "Request" in _json["data"]["context"]["request"]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("app", [create_app(context={"request": "test"})])
 async def test_request_not_replaced(app, client):

--- a/tests/flask/schema.py
+++ b/tests/flask/schema.py
@@ -29,6 +29,10 @@ QueryRootType = GraphQLObjectType(
                         GraphQLNonNull(GraphQLString),
                         resolve=lambda obj, info: info.context["request"],
                     ),
+                    "property": GraphQLField(
+                        GraphQLString,
+                        resolve=lambda obj, info: info.context.property
+                    ),
                 },
             ),
             resolve=lambda obj, info: info.context,

--- a/tests/flask/schema.py
+++ b/tests/flask/schema.py
@@ -30,8 +30,7 @@ QueryRootType = GraphQLObjectType(
                         resolve=lambda obj, info: info.context["request"],
                     ),
                     "property": GraphQLField(
-                        GraphQLString,
-                        resolve=lambda obj, info: info.context.property
+                        GraphQLString, resolve=lambda obj, info: info.context.property
                     ),
                 },
             ),

--- a/tests/flask/test_graphqlview.py
+++ b/tests/flask/test_graphqlview.py
@@ -518,6 +518,23 @@ def test_context_remapped_if_not_mapping(app, client):
     assert "Request" in res["data"]["context"]["request"]
 
 
+class CustomContext(dict):
+    property = "A custom property"
+
+
+@pytest.mark.parametrize("app", [create_app(context=CustomContext())])
+def test_allow_empty_custom_context(app, client):
+    response = client.get(url_string(app, query="{context { property request }}"))
+
+    assert response.status_code == 200
+    res = response_json(response)
+    assert "data" in res
+    assert "request" in res["data"]["context"]
+    assert "property" in res["data"]["context"]
+    assert "A custom property" == res["data"]["context"]["property"]
+    assert "Request" in res["data"]["context"]["request"]
+
+
 def test_post_multipart_data(app, client):
     query = "mutation TestMutation { writeTest { test } }"
     response = client.post(

--- a/tests/quart/schema.py
+++ b/tests/quart/schema.py
@@ -29,6 +29,10 @@ QueryRootType = GraphQLObjectType(
                         GraphQLNonNull(GraphQLString),
                         resolve=lambda obj, info: info.context["request"],
                     ),
+                    "property": GraphQLField(
+                        GraphQLString,
+                        resolve=lambda obj, info: info.context.property
+                    ),
                 },
             ),
             resolve=lambda obj, info: info.context,

--- a/tests/quart/schema.py
+++ b/tests/quart/schema.py
@@ -30,8 +30,7 @@ QueryRootType = GraphQLObjectType(
                         resolve=lambda obj, info: info.context["request"],
                     ),
                     "property": GraphQLField(
-                        GraphQLString,
-                        resolve=lambda obj, info: info.context.property
+                        GraphQLString, resolve=lambda obj, info: info.context.property
                     ),
                 },
             ),

--- a/tests/quart/test_graphqlview.py
+++ b/tests/quart/test_graphqlview.py
@@ -654,9 +654,7 @@ class CustomContext(dict):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("app", [create_app(context=CustomContext())])
-async def test_allow_empty_custom_context(
-    app: Quart, client: TestClientProtocol
-):
+async def test_allow_empty_custom_context(app: Quart, client: TestClientProtocol):
     response = await execute_client(app, client, query="{context { property request }}")
 
     assert response.status_code == 200

--- a/tests/quart/test_graphqlview.py
+++ b/tests/quart/test_graphqlview.py
@@ -648,6 +648,27 @@ async def test_context_remapped_if_not_mapping(app: Quart, client: TestClientPro
     assert "Request" in res["data"]["context"]["request"]
 
 
+class CustomContext(dict):
+    property = "A custom property"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("app", [create_app(context=CustomContext())])
+async def test_allow_empty_custom_context(
+    app: Quart, client: TestClientProtocol
+):
+    response = await execute_client(app, client, query="{context { property request }}")
+
+    assert response.status_code == 200
+    result = await response.get_data(as_text=True)
+    res = response_json(result)
+    assert "data" in res
+    assert "request" in res["data"]["context"]
+    assert "property" in res["data"]["context"]
+    assert "A custom property" == res["data"]["context"]["property"]
+    assert "Request" in res["data"]["context"]["request"]
+
+
 # @pytest.mark.asyncio
 # async def test_post_multipart_data(app: Quart, client: TestClientProtocol):
 #     query = "mutation TestMutation { writeTest { test } }"

--- a/tests/sanic/schema.py
+++ b/tests/sanic/schema.py
@@ -33,8 +33,7 @@ QueryRootType = GraphQLObjectType(
                         resolve=lambda obj, info: info.context["request"],
                     ),
                     "property": GraphQLField(
-                        GraphQLString,
-                        resolve=lambda obj, info: info.context.property
+                        GraphQLString, resolve=lambda obj, info: info.context.property
                     ),
                 },
             ),

--- a/tests/sanic/schema.py
+++ b/tests/sanic/schema.py
@@ -32,6 +32,10 @@ QueryRootType = GraphQLObjectType(
                         GraphQLNonNull(GraphQLString),
                         resolve=lambda obj, info: info.context["request"],
                     ),
+                    "property": GraphQLField(
+                        GraphQLString,
+                        resolve=lambda obj, info: info.context.property
+                    ),
                 },
             ),
             resolve=lambda obj, info: info.context,

--- a/tests/sanic/test_graphqlview.py
+++ b/tests/sanic/test_graphqlview.py
@@ -498,6 +498,25 @@ def test_passes_custom_context_into_context(app):
     assert "Request" in res["data"]["context"]["request"]
 
 
+class CustomContext(dict):
+    property = "A custom property"
+
+
+@pytest.mark.parametrize("app", [create_app(context=CustomContext())])
+def test_allow_empty_custom_context(app):
+    _, response = app.test_client.get(
+        uri=url_string(query="{context { property request }}")
+    )
+
+    assert response.status_code == 200
+    res = response_json(response)
+    assert "data" in res
+    assert "request" in res["data"]["context"]
+    assert "property" in res["data"]["context"]
+    assert "A custom property" == res["data"]["context"]["property"]
+    assert "Request" in res["data"]["context"]["request"]
+
+
 @pytest.mark.parametrize("app", [create_app(context="CUSTOM CONTEXT")])
 def test_context_remapped_if_not_mapping(app):
     _, response = app.test_client.get(

--- a/tests/webob/schema.py
+++ b/tests/webob/schema.py
@@ -31,8 +31,7 @@ QueryRootType = GraphQLObjectType(
                         resolve=lambda obj, info: info.context["request"],
                     ),
                     "property": GraphQLField(
-                        GraphQLString,
-                        resolve=lambda obj, info: info.context.property
+                        GraphQLString, resolve=lambda obj, info: info.context.property
                     ),
                 },
             ),

--- a/tests/webob/schema.py
+++ b/tests/webob/schema.py
@@ -30,6 +30,10 @@ QueryRootType = GraphQLObjectType(
                         GraphQLNonNull(GraphQLString),
                         resolve=lambda obj, info: info.context["request"],
                     ),
+                    "property": GraphQLField(
+                        GraphQLString,
+                        resolve=lambda obj, info: info.context.property
+                    ),
                 },
             ),
             resolve=lambda obj, info: info.context,

--- a/tests/webob/test_graphqlview.py
+++ b/tests/webob/test_graphqlview.py
@@ -471,6 +471,23 @@ def test_context_remapped_if_not_mapping(client, settings):
     assert "request" in res["data"]["context"]["request"]
 
 
+class CustomContext(dict):
+    property = "A custom property"
+
+
+@pytest.mark.parametrize("settings", [dict(context=CustomContext())])
+def test_allow_empty_custom_context(client, settings):
+    response = client.get(url_string(query="{context { property request }}"))
+
+    assert response.status_code == 200
+    res = response_json(response)
+    assert "data" in res
+    assert "request" in res["data"]["context"]
+    assert "property" in res["data"]["context"]
+    assert "A custom property" == res["data"]["context"]["property"]
+    assert "request" in res["data"]["context"]["request"]
+
+
 def test_post_multipart_data(client):
     query = "mutation TestMutation { writeTest { test } }"
     data = (


### PR DESCRIPTION
From PEP-8: "beware of writing if x when you really mean if x is not None – e.g. when testing whether a variable or argument that defaults to None was set to some other value. The other value might have a type (such as a container) that could be false in a boolean context!"

Currently a custom MutableMapping cannot be used as a graphql context if it is passed to GraphQLView empty