### PR TITLE
Update pypi publishing github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
         pip install wheel
         python setup.py sdist
     - name: Publish a Python distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Update the `pypa/gh-action-pypi-publish` github action to use the latest v1. We're using `v1.1.0` that's 3 years old. The current one is `v1.8.5`. Nothing else needs updating according to the doc.