### PR TITLE
Fix bugs with transport-ws-protocol

### DIFF
--- a/graphql_server/channels/graphql_transport_ws.py
+++ b/graphql_server/channels/graphql_transport_ws.py
@@ -24,10 +24,10 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         self._ws = ws
 
     async def get_context(self) -> Any:
-        return await self._get_context(request=self._ws)
+        return await self._get_context(self._ws)
 
     async def get_root_value(self) -> Any:
-        return await self._get_root_value(request=self._ws)
+        return await self._get_root_value(self._ws)
 
     async def send_json(self, data: dict) -> None:
         await self._ws.send_json(data)
@@ -37,9 +37,7 @@ class GraphQLTransportWSHandler(BaseGraphQLTransportWSHandler):
         await self._ws.close(code=code)
 
     async def handle_request(self) -> Any:
-        await self._ws.accept(
-            subprotocol=BaseGraphQLTransportWSHandler.GRAPHQL_TRANSPORT_WS_PROTOCOL
-        )
+        await self._ws.accept(subprotocol=BaseGraphQLTransportWSHandler.PROTOCOL)
 
     async def handle_disconnect(self, code):
         for operation_id in list(self.subscriptions.keys()):

--- a/graphql_server/websockets/transport_ws_protocol/types.py
+++ b/graphql_server/websockets/transport_ws_protocol/types.py
@@ -5,6 +5,8 @@ try:
 except ImportError:
     from typing_extensions import TypedDict
 
+from dataclasses import dataclass, asdict
+
 from .contstants import (
     GQL_CONNECTION_INIT,
     GQL_CONNECTION_ACK,
@@ -17,84 +19,103 @@ from .contstants import (
 )
 
 
-class ConnectionInitMessage(TypedDict):
+class Message:
+    def asdict(self):
+        return {key: value for key, value in asdict(self).items() if value is not None}
+
+
+@dataclass
+class ConnectionInitMessage(Message):
     """
     Direction: Client -> Server
     """
 
-    payload: Optional[Dict[str, Any]]
-    type = GQL_CONNECTION_INIT
+    payload: Optional[Dict[str, Any]] = None
+    type: str = GQL_CONNECTION_INIT
 
 
-class ConnectionAckMessage(TypedDict):
+@dataclass
+class ConnectionAckMessage(Message):
     """
     Direction: Server -> Client
     """
 
-    payload: Optional[Dict[str, Any]]
-    type = GQL_CONNECTION_ACK
+    payload: Optional[Dict[str, Any]] = None
+    type: str = GQL_CONNECTION_ACK
 
 
-class PingMessage(TypedDict):
+@dataclass
+class PingMessage(Message):
     """
     Direction: bidirectional
     """
 
-    payload: Optional[Dict[str, Any]]
-    type = GQL_PING
+    payload: Optional[Dict[str, Any]] = None
+    type: str = GQL_PING
 
 
-class PongMessage(TypedDict):
+@dataclass
+class PongMessage(Message):
     """
     Direction: bidirectional
     """
 
-    payload: Optional[Dict[str, Any]]
-    type = GQL_PONG
+    payload: Optional[Dict[str, Any]] = None
+    type: str = GQL_PONG
 
 
-class SubscribeMessagePayload(TypedDict):
+@dataclass
+class SubscribeMessagePayload(Message):
     query: str
-    operationName: Optional[str]
-    variables: Optional[Dict[str, Any]]
-    extensions: Optional[Dict[str, Any]]
+    operationName: Optional[str] = None
+    variables: Optional[Dict[str, Any]] = None
+    extensions: Optional[Dict[str, Any]] = None
 
 
-class SubscribeMessage(TypedDict):
+@dataclass
+class SubscribeMessage(Message):
     """
     Direction: Client -> Server
     """
 
     id: str
     payload: SubscribeMessagePayload
-    type = GQL_SUBSCRIBE
+    type: str = GQL_SUBSCRIBE
+
+    @classmethod
+    def from_dict(cls, message: dict):
+        subscribe_message = cls(**message)
+        subscribe_message.payload = SubscribeMessagePayload(**subscribe_message.payload)
+        return subscribe_message
 
 
-class NextMessage(TypedDict):
+@dataclass
+class NextMessage(Message):
     """
     Direction: Server -> Client
     """
 
     id: str
     payload: Dict[str, Any]  # TODO: shape like ExecutionResult
-    type = GQL_NEXT
+    type: str = GQL_NEXT
 
 
-class ErrorMessage(TypedDict):
+@dataclass
+class ErrorMessage(Message):
     """
     Direction: Server -> Client
     """
 
     id: str
     payload: List[Dict[str, Any]]  # TODO: shape like List[GraphQLError]
-    type = GQL_ERROR
+    type: str = GQL_ERROR
 
 
-class CompleteMessage(TypedDict):
+@dataclass
+class CompleteMessage(Message):
     """
     Direction: bidirectional
     """
 
-    type = GQL_COMPLETE
-
     id: str
+    type: str = GQL_COMPLETE


### PR DESCRIPTION
I am guessing the `v3` branch was only used with `GraphQLWSHandler`, and not with `GraphQLTransportWSHandler`. That's probably why there were a bunch of bugs. This PR fixes the errors I got when trying to use subscriptions with the `graphql-transport-ws` protocol.

The first error I got was
```
Can't instantiate abstract class GraphQLTransportWSHandler with abstract method send_xjson
```
I implemented this function and the error went away.

Second error was with message types - they were `TypedDict`s, but typeddicts are essentially dicts.
This means additional fields specified are not properly used. I fixed it by converting them to `dataclasses` and adding a `to_dict` field to it.