### PR TITLE
chore: replace black with ruff formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,9 @@ repos:
     rev: "0.49"
     hooks:
     -   id: check-manifest
--   repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-    -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.0
+    rev: v0.1.2
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
+    -   id: ruff-format

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -25,7 +25,6 @@ target-version = "py38"
 
 [isort]
 known-first-party = ["graphql_server"]
-force-wrap-aliases = true
 combine-as-imports = true
 
 [pyupgrade]

--- a/tests/aiohttp/test_graphiqlview.py
+++ b/tests/aiohttp/test_graphiqlview.py
@@ -27,7 +27,7 @@ async def test_graphiql_is_enabled(app, client):
         '    "test": "Hello World"\n'
         "  }\n"
         "}".replace('"', '\\"').replace("\n", "\\n")
-    )
+    )  # fmt: skip
 
     assert pretty_response in await response.text()
 

--- a/tests/flask/test_graphiqlview.py
+++ b/tests/flask/test_graphiqlview.py
@@ -33,7 +33,7 @@ def test_graphiql_renders_pretty(app, client):
         '    "test": "Hello World"\n'
         "  }\n"
         "}".replace('"', '\\"').replace("\n", "\\n")
-    )
+    )  # fmt: skip
 
     assert pretty_response in response.data.decode("utf-8")
 

--- a/tests/quart/test_graphiqlview.py
+++ b/tests/quart/test_graphiqlview.py
@@ -15,7 +15,7 @@ async def execute_client(
     client: TestClientProtocol,
     method: str = "GET",
     headers: Optional[Headers] = None,
-    **extra_params
+    **extra_params,
 ) -> Response:
     test_request_context = app.test_request_context(path="/", method=method)
     async with test_request_context:
@@ -51,7 +51,7 @@ async def test_graphiql_renders_pretty(app: Quart, client: TestClientProtocol):
         '    "test": "Hello World"\n'
         "  }\n"
         "}".replace('"', '\\"').replace("\n", "\\n")
-    )
+    )  # fmt: skip
     result = await response.get_data(as_text=True)
     assert pretty_response in result
 

--- a/tests/sanic/test_graphiqlview.py
+++ b/tests/sanic/test_graphiqlview.py
@@ -26,7 +26,7 @@ def test_graphiql_is_enabled(app):
         '    "test": "Hello World"\n'
         "  }\n"
         "}".replace('"', '\\"').replace("\n", "\\n")
-    )
+    )  # fmt: skip
 
     assert pretty_response in response.body.decode("utf-8")
 

--- a/tests/webob/test_graphiqlview.py
+++ b/tests/webob/test_graphiqlview.py
@@ -24,7 +24,7 @@ def test_graphiql_simple_renderer(client):
         '    "test": "Hello World"\n'
         "  }\n"
         "}".replace('"', '\\"').replace("\n", "\\n")
-    )
+    )  # fmt: skip
     assert pretty_response in response.body.decode("utf-8")
 
 


### PR DESCRIPTION
ruff formatter (black-compatible code formatter built in ruff) is out of beta https://astral.sh/blog/the-ruff-formatter.