### PR TITLE
Fix typos and improve docs

### DIFF
--- a/docs/aiohttp.md
+++ b/docs/aiohttp.md
@@ -4,7 +4,7 @@ Adds GraphQL support to your aiohttp application.
 
 ## Installation
 
-To install the integration with aiohttp, run the below command on your terminal.
+To install the integration with aiohttp, run the following command in your terminal.
 
 `pip install graphql-server[aiohttp]`
 

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -4,7 +4,7 @@ Adds GraphQL support to your Flask application.
 
 ## Installation
 
-To install the integration with Flask, run the below command on your terminal.
+To install the integration with Flask, run the following command in your terminal.
 
 `pip install graphql-server[flask]`
 

--- a/docs/sanic.md
+++ b/docs/sanic.md
@@ -4,7 +4,7 @@ Adds GraphQL support to your Sanic application.
 
 ## Installation
 
-To install the integration with Sanic, run the below command on your terminal.
+To install the integration with Sanic, run the following command in your terminal.
 
 `pip install graphql-server[sanic]`
 

--- a/docs/webob.md
+++ b/docs/webob.md
@@ -4,7 +4,7 @@ Adds GraphQL support to your WebOb (Pyramid, Pylons, ...) application.
 
 ## Installation
 
-To install the integration with WebOb, run the below command on your terminal.
+To install the integration with WebOb, run the following command in your terminal.
 
 `pip install graphql-server[webob]`
 

--- a/src/graphql_server/channels/handlers/base.py
+++ b/src/graphql_server/channels/handlers/base.py
@@ -96,7 +96,7 @@ class ChannelsConsumer(AsyncConsumer):
             groups:
                 An optional sequence of groups to receive messages from.
                 When passing this parameter, the groups will be registered
-                using `self.channel_layer.group_add` at the beggining of the
+                using `self.channel_layer.group_add` at the beginning of the
                 execution and then discarded using `self.channel_layer.group_discard`
                 at the end of the execution.
         """
@@ -155,7 +155,7 @@ class ChannelsConsumer(AsyncConsumer):
             groups:
                 An optional sequence of groups to receive messages from.
                 When passing this parameter, the groups will be registered
-                using `self.channel_layer.group_add` at the beggining of the
+                using `self.channel_layer.group_add` at the beginning of the
                 execution and then discarded using `self.channel_layer.group_discard`
                 at the end of the execution.
         """
@@ -192,7 +192,7 @@ class ChannelsConsumer(AsyncConsumer):
     ) -> AsyncGenerator[Any, None]:
         """Generator for listen_to_channel method.
 
-        Seperated to allow user code to be run after subscribing to channels
+        Separated to allow user code to be run after subscribing to channels
         and before blocking to wait for incoming channel messages.
         """
         while True:

--- a/src/graphql_server/http/sync_base_view.py
+++ b/src/graphql_server/http/sync_base_view.py
@@ -170,7 +170,7 @@ class SyncBaseHTTPView(
             data = self.parse_multipart(request)
         elif self._is_multipart_subscriptions(content_type, params):
             raise HTTPException(
-                400, "Multipart subcriptions are not supported in sync mode"
+                400, "Multipart subscriptions are not supported in sync mode"
             )
         else:
             raise HTTPException(400, "Unsupported content type")

--- a/src/graphql_server/subscriptions/protocols/graphql_transport_ws/handlers.py
+++ b/src/graphql_server/subscriptions/protocols/graphql_transport_ws/handlers.py
@@ -162,7 +162,7 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
 
     async def handle_connection_init(self, message: ConnectionInitMessage) -> None:
         if self.connection_timed_out:
-            # No way to reliably excercise this case during testing
+            # No way to reliably exercise this case during testing
             return  # pragma: no cover
 
         if self.connection_init_timeout_task:
@@ -343,7 +343,7 @@ class BaseGraphQLTransportWSHandler(Generic[Context, RootValue]):
 
     def forget_id(self, id: str) -> None:
         # de-register the operation id making it immediately available
-        # for re-use
+        # for reuse
         del self.operations[id]
 
     async def handle_complete(self, message: CompleteMessage) -> None:

--- a/src/tests/http/test_graphql_over_http_spec.py
+++ b/src/tests/http/test_graphql_over_http_spec.py
@@ -179,7 +179,7 @@ async def test_423l(http_client):
 
 @pytest.mark.parametrize(
     "invalid",
-    [{"obj": "ect"}, 0, False, ["array"]],
+    [{"obj": "etc"}, 0, False, ["array"]],
     ids=["LKJ0", "LKJ1", "LKJ2", "LKJ3"],
 )
 async def test_lkj_(http_client, invalid):
@@ -222,7 +222,7 @@ async def test_13ee(http_client):
 
 @pytest.mark.parametrize(
     "invalid",
-    [{"obj": "ect"}, 0, False, ["array"]],
+    [{"obj": "etc"}, 0, False, ["array"]],
     ids=["6C00", "6C01", "6C02", "6C03"],
 )
 async def test_6c0_(http_client, invalid):

--- a/src/tests/websockets/test_graphql_transport_ws.py
+++ b/src/tests/websockets/test_graphql_transport_ws.py
@@ -422,8 +422,8 @@ async def test_duplicated_operation_ids(ws: WebSocketClient):
 
 
 async def test_reused_operation_ids(ws: WebSocketClient):
-    """Test that an operation id can be re-used after it has been
-    previously used for a completed operation.
+    """Test that an operation id can be reused after it has been
+        previously used for a completed operation.
     """
     # Use sub1 as an id for an operation
     await ws.send_message(
@@ -1126,7 +1126,7 @@ async def test_error_handler_for_timeout(http_client: HttpClient):
             assert connection_ack_message == {"type": "connection_ack"}
             await ws.close()
 
-    # the error hander should have been called
+    # the error handler should have been called
     assert handler
     errorhandler.assert_called_once()
     args = errorhandler.call_args

--- a/src/tests/websockets/test_graphql_ws.py
+++ b/src/tests/websockets/test_graphql_ws.py
@@ -311,8 +311,8 @@ async def test_sends_keep_alive(http_client_class: type[HttpClient]):
         ack_message: ConnectionAckMessage = await ws.receive_json()
         assert ack_message["type"] == "connection_ack"
 
-        # we can't be sure how many keep-alives exactly we
-        # get but they should be more than one.
+        # We can't be sure how many keep-alive messages exactly we
+        # get, but there should be more than one.
         keepalive_count = 0
         while True:
             ka_or_data_message: Union[


### PR DESCRIPTION
## Summary
- fix typos in channels handler, websocket handler, and sync view
- update comments and docstrings in websocket tests
- clarify installation instructions in framework docs
- adjust invalid test data spelling

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_b_68686e4c9610833180e8fd925b8d1aef